### PR TITLE
#1 fix: preserve previous release link when re-releasing a version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Refactored the internal changelog validation helper into smaller private functions so the validation workflow keeps the same behavior while reducing method size and complexity ahead of `1.0.0`.
+- Fixed `Move-UnreleasedChangelog` so re-releasing the same version after moving its notes back into `Unreleased` reuses the real previous release reference instead of generating a self-compare link.
 
 ### Security
 

--- a/src/private/release/Get-KeepAChangelogPreviousReleaseReference.ps1
+++ b/src/private/release/Get-KeepAChangelogPreviousReleaseReference.ps1
@@ -1,0 +1,54 @@
+function Get-ChangelogReleaseTargetReference {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Link
+    )
+
+    $compareMatch = [regex]::Match($Link, '/compare/.+\.\.\.(?<target>.+)$')
+    if ($compareMatch.Success) {
+        return $compareMatch.Groups['target'].Value
+    }
+
+    $tagMatch = [regex]::Match($Link, '/releases/tag/(?<target>.+)$')
+    if ($tagMatch.Success) {
+        return $tagMatch.Groups['target'].Value
+    }
+
+    return $null
+}
+
+function Get-KeepAChangelogPreviousReleaseReference {
+    [CmdletBinding()]
+    param(
+        [AllowEmptyString()]
+        [string]$Footer,
+        [Parameter(Mandatory)]
+        [pscustomobject]$Validation,
+        [Parameter(Mandatory)]
+        [pscustomobject]$Release
+    )
+
+    $previousReleaseReference = $Validation.PreviousReleaseReference
+    if ([string]::IsNullOrWhiteSpace($previousReleaseReference)) {
+        return $null
+    }
+
+    if ($previousReleaseReference -ne $Release.Tag) {
+        return $previousReleaseReference
+    }
+
+    $referenceLinkData = Get-ChangelogReferenceLinkData -Footer $Footer
+    foreach ($releaseVersion in $Validation.ReleaseVersions) {
+        if (-not $referenceLinkData.LinkMap.Contains($releaseVersion)) {
+            continue
+        }
+
+        $releaseTargetReference = Get-ChangelogReleaseTargetReference -Link $referenceLinkData.LinkMap[$releaseVersion]
+        if (-not [string]::IsNullOrWhiteSpace($releaseTargetReference) -and $releaseTargetReference -ne $Release.Tag) {
+            return $releaseTargetReference
+        }
+    }
+
+    return $null
+}

--- a/src/private/release/Resolve-KeepAChangelogReleaseData.ps1
+++ b/src/private/release/Resolve-KeepAChangelogReleaseData.ps1
@@ -14,6 +14,10 @@ function Get-KeepAChangelogRepositoryContext {
     [CmdletBinding()]
     param(
         [string]$RepositoryUrl,
+        [AllowEmptyString()]
+        [string]$Footer,
+        [Parameter(Mandatory)]
+        [pscustomobject]$Release,
         [Parameter(Mandatory)]
         [pscustomobject]$Validation
     )
@@ -38,10 +42,15 @@ function Get-KeepAChangelogRepositoryContext {
         $normalizedRepositoryUrl = $unreleasedCompareLinkPrefix -replace '/compare/$', ''
     }
 
+    $previousReleaseReference = Get-KeepAChangelogPreviousReleaseReference `
+        -Footer $Footer `
+        -Validation $Validation `
+        -Release $Release
+
     return [pscustomobject]@{
         RepositoryUrl               = $normalizedRepositoryUrl
         UnreleasedCompareLinkPrefix = $unreleasedCompareLinkPrefix
-        PreviousReleaseReference    = $Validation.PreviousReleaseReference
+        PreviousReleaseReference    = $previousReleaseReference
     }
 }
 
@@ -106,7 +115,11 @@ function Resolve-KeepAChangelogReleaseData {
     Assert-KeepAChangelogValidation -Validation $validation
     $parts = Split-KeepAChangelogText -Text $Text
     $unreleasedSectionMatch = Get-UnreleasedSectionMatch -Text $parts.Body
-    $repositoryContext = Get-KeepAChangelogRepositoryContext -RepositoryUrl $RepositoryUrl -Validation $validation
+    $repositoryContext = Get-KeepAChangelogRepositoryContext `
+        -RepositoryUrl $RepositoryUrl `
+        -Footer $parts.Footer `
+        -Release $normalizedRelease `
+        -Validation $validation
     $unreleasedBody = $unreleasedSectionMatch.Groups['body'].Value.Trim()
     $releaseNotesBody = Get-ChangelogReleaseNotesBody -Body $unreleasedBody
     $clearedUnreleasedBody = Get-ClearedUnreleasedBody -Body $unreleasedBody

--- a/tests/KeepAChangelog.Coverage.Tests.ps1
+++ b/tests/KeepAChangelog.Coverage.Tests.ps1
@@ -164,6 +164,40 @@ Describe 'Private helper coverage' {
 
         $result | Should -Be 'Plain text line'
     }
+
+    It 'extracts the target from release tag links' {
+        InModuleScope KeepAChangelog {
+            $result = Get-ChangelogReleaseTargetReference -Link 'https://github.com/example/repo/releases/tag/1.0.0'
+
+            $result | Should -Be '1.0.0'
+        }
+    }
+
+    It 'returns null when a link is not a compare or tag link' {
+        InModuleScope KeepAChangelog {
+            $result = Get-ChangelogReleaseTargetReference -Link 'https://github.com/example/repo/issues/123'
+
+            $result | Should -BeNullOrEmpty
+        }
+    }
+
+    It 'returns null when no usable previous release reference can be recovered' {
+        InModuleScope KeepAChangelog {
+            $result = Get-KeepAChangelogPreviousReleaseReference `
+                -Footer @'
+[0.9.0]: https://github.com/example/repo/releases/tag/1.0.0
+'@ `
+                -Validation ([pscustomobject]@{
+                    PreviousReleaseReference = '1.0.0'
+                    ReleaseVersions          = @('0.9.0')
+                }) `
+                -Release ([pscustomobject]@{
+                    Tag = '1.0.0'
+                })
+
+            $result | Should -BeNullOrEmpty
+        }
+    }
 }
 
 Describe 'Validation result edge cases' {

--- a/tests/KeepAChangelog.Tests.ps1
+++ b/tests/KeepAChangelog.Tests.ps1
@@ -243,6 +243,38 @@ Describe 'Move-UnreleasedChangelog' {
         ([regex]::Matches($updated, '(?m)^\[1\.6\.0\]:').Count) | Should -Be 1
     }
 
+    It 'reuses the last remaining release reference when the same version is released again' {
+        $path = Join-Path $TestDrive 'CHANGELOG.md'
+
+        @'
+# Changelog
+
+## [Unreleased]
+
+### Fixed
+
+- Release notes moved back for editing.
+
+## [0.0.1] - 2026-05-01
+
+### Added
+
+- Initial release.
+
+[Unreleased]: https://github.com/example/repo/compare/0.1.0...HEAD
+[0.0.1]: https://github.com/example/repo/compare/develop...0.0.1
+'@ | Set-Content -LiteralPath $path -Encoding utf8
+
+        $result = Move-UnreleasedChangelog -Path $path -Version '0.1.0' -Date '2026-05-04'
+        $updated = Get-Content -LiteralPath $path -Raw
+
+        $result.PreviousReleaseReference | Should -Be '0.0.1'
+        $result.NewReleaseCompareLink | Should -Be 'https://github.com/example/repo/compare/0.0.1...0.1.0'
+        $updated | Should -Match '\[Unreleased\]: https://github\.com/example/repo/compare/0\.1\.0\.\.\.HEAD'
+        $updated | Should -Match '\[0\.1\.0\]: https://github\.com/example/repo/compare/0\.0\.1\.\.\.0\.1\.0'
+        $updated | Should -Not -Match '\[0\.1\.0\]: https://github\.com/example/repo/compare/0\.1\.0\.\.\.0\.1\.0'
+    }
+
     It 'adds footer links on the first release when the changelog started without a previous release reference' {
         $path = Join-Path $TestDrive 'CHANGELOG.md'
 


### PR DESCRIPTION
Summary

 - Fixed Move-UnreleasedChangelog so re-releasing the same version after manually moving its notes back into ## [Unreleased] no longer generates a self-compare link like 0.1.0...0.1.0.
 - The release-resolution path now falls back to the real previous release reference from the remaining release footer/history when the [Unreleased] link already points at the version being released, and a regression test covers that retry scenario.
 - This was needed because the previous logic trusted [Unreleased] as the source of truth for PreviousReleaseReference, which breaks when a release is temporarily rolled back for editing and then released again.
 - Closes #1.

Affected area

 - [ ]  nova CLI or command routing
 - [X]  Public PowerShell cmdlet behavior
 - [ ]  Scaffolding or project.json handling
 - [ ]  Build, test, analyzer, coverage, or CI helper flow
 - [ ]  Package, raw upload, or package metadata workflow
 - [ ]  Publish, release, semantic-release, or GitHub Actions automation
 - [ ]  Self-update or notification preference behavior
 - [ ]  Contributor documentation (README.md, CONTRIBUTING.md, repository workflow docs)
 - [ ]  End-user docs (docs/*.html)
 - [ ]  Command help (docs/NovaModuleTools/en-US/*.md)
 - [ ]  src/resources/example/
 - [ ]  Dependency or manifest changes (package.json, workflow dependencies, release tooling)
 - [ ]  Security-sensitive change
 - [ ]  Documentation-only change
 - [X]  Other

Review guidance

Start with src/private/release/Resolve-KeepAChangelogReleaseData.ps1 and the new helper src/private/release/Get-KeepAChangelogPreviousReleaseReference.ps1.

The key review path is:

 1. how PreviousReleaseReference is resolved for retrying the same version
 2. how that value feeds Get-UpdatedChangelogReferenceFooter
 3. the regression coverage in tests/KeepAChangelog.Tests.ps1

Primary files changed:

 - src/private/release/Resolve-KeepAChangelogReleaseData.ps1
 - src/private/release/Get-KeepAChangelogPreviousReleaseReference.ps1
 - tests/KeepAChangelog.Tests.ps1
 - CHANGELOG.md

Trade-off / limitation:

 - The fallback logic is intentionally narrow: it only overrides the [Unreleased]-derived reference when it matches the current release tag, so normal release behavior stays unchanged.

Validation

 - [X]  Invoke-NovaBuild
 - [X]  Test-NovaBuild
 - [X]  ./scripts/build/Invoke-ScriptAnalyzerCI.ps1
 - [ ]  ./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1
 - [ ]  Targeted Nova workflow validated (% nova build, % nova test, % nova merge, % nova deploy,
 % nova publish,
 % nova release, % nova update, % nova notification, or % nova init as relevant)
 - [ ]  Docs/example only; executable validation not needed

Validation notes:

 Ran:
 - Import-Module NovaModuleTools -ErrorAction Stop; Invoke-NovaBuild; Test-NovaBuild
 - ./scripts/build/Invoke-ScriptAnalyzerCI.ps1
 
 Result:
 - Build passed
 - Pester passed: 37 tests, 0 failed
 - ScriptAnalyzer still reports the same 4 pre-existing warnings already tracked in the repo baseline; no new warnings were introduced by this change
 
 Skipped:
 - ./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1 was not rerun for this scoped release-link fix
 - No separate nova CLI workflow command was exercised because the affected behavior is covered through the module build/test path

Documentation and release follow-up

 - [ ]  README.md reviewed and updated if contributor workflow, architecture, CI, release, or automation changed
 - [ ]  CONTRIBUTING.md reviewed and updated if contribution expectations or review guidance changed
 - [X]  CHANGELOG.md reviewed and updated if the change matters to users, maintainers, or contributors
 - [ ]  docs/NovaModuleTools/en-US/ help updated if a public command or CLI behavior changed
 - [ ]  docs/*.html updated if end-user workflows or examples changed
 - [ ]  src/resources/example/ reviewed and updated if the real-world project layout, package model, or upload workflow
 changed
 - [ ]  No documentation, changelog, or example updates were needed

Maintainability, compatibility, and risk

 - [X]  Code Health / maintainability impact considered
 - [X]  No breaking change
 - [ ]  Breaking change
 - [ ]  Security-sensitive change
 - [ ]  CI, workflow, or release-pipeline impact
 - [ ]  Dependency-review impact

Risk, rollout, or rollback notes:

 Low risk and backward-compatible.
 
 The change is limited to the release-footer/reference resolution path used by Move-UnreleasedChangelog.
 Normal release behavior still uses the existing [Unreleased] compare link when it does not point at the current release tag.
 
 Rollback is straightforward: revert the new previous-release-resolution helper and the related call-site change in Resolve-KeepAChangelogReleaseData.ps1.
