### PR TITLE
#2 feat: enforce chronological release dates in Move-UnreleasedChangelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Refactored the internal changelog validation helper into smaller private functions so the validation workflow keeps the same behavior while reducing method size and complexity ahead of `1.0.0`.
 - Fixed `Move-UnreleasedChangelog` so re-releasing the same version after moving its notes back into `Unreleased` reuses the real previous release reference instead of generating a self-compare link.
+- Fixed `Move-UnreleasedChangelog` so a new release date cannot be earlier than the latest existing release date in `CHANGELOG.md`, while still allowing first releases and same-day releases.
 
 ### Security
 

--- a/src/private/release/Assert-KeepAChangelogReleaseDateOrder.ps1
+++ b/src/private/release/Assert-KeepAChangelogReleaseDateOrder.ps1
@@ -1,0 +1,56 @@
+function Get-KeepAChangelogLatestReleaseDate {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Body
+    )
+
+    $latestReleaseDate = $null
+    foreach ($match in [regex]::Matches($Body, '(?m)^## \[[^\]]+\] - (?<date>\d{4}-\d{2}-\d{2})$')) {
+        $releaseDate = [datetime]::ParseExact(
+            $match.Groups['date'].Value,
+            'yyyy-MM-dd',
+            [System.Globalization.CultureInfo]::InvariantCulture
+        )
+
+        if ($null -eq $latestReleaseDate -or $releaseDate -gt $latestReleaseDate) {
+            $latestReleaseDate = $releaseDate
+        }
+    }
+
+    if ($null -eq $latestReleaseDate) {
+        return $null
+    }
+
+    return $latestReleaseDate.ToString('yyyy-MM-dd', [System.Globalization.CultureInfo]::InvariantCulture)
+}
+
+function Assert-KeepAChangelogReleaseDateOrder {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Body,
+        [Parameter(Mandatory)]
+        [pscustomobject]$Release
+    )
+
+    $latestExistingReleaseDate = Get-KeepAChangelogLatestReleaseDate -Body $Body
+    if ([string]::IsNullOrWhiteSpace($latestExistingReleaseDate)) {
+        return
+    }
+
+    $releaseDate = [datetime]::ParseExact(
+        $Release.Date,
+        'yyyy-MM-dd',
+        [System.Globalization.CultureInfo]::InvariantCulture
+    )
+    $latestReleaseDate = [datetime]::ParseExact(
+        $latestExistingReleaseDate,
+        'yyyy-MM-dd',
+        [System.Globalization.CultureInfo]::InvariantCulture
+    )
+
+    if ($releaseDate -lt $latestReleaseDate) {
+        throw "Release.Date '$($Release.Date)' cannot be earlier than latest existing release date '$latestExistingReleaseDate'."
+    }
+}

--- a/src/private/release/Resolve-KeepAChangelogReleaseData.ps1
+++ b/src/private/release/Resolve-KeepAChangelogReleaseData.ps1
@@ -114,6 +114,7 @@ function Resolve-KeepAChangelogReleaseData {
     $validation = Get-KeepAChangelogValidationResult -Text $Text
     Assert-KeepAChangelogValidation -Validation $validation
     $parts = Split-KeepAChangelogText -Text $Text
+    Assert-KeepAChangelogReleaseDateOrder -Body $parts.Body -Release $normalizedRelease
     $unreleasedSectionMatch = Get-UnreleasedSectionMatch -Text $parts.Body
     $repositoryContext = Get-KeepAChangelogRepositoryContext `
         -RepositoryUrl $RepositoryUrl `

--- a/tests/KeepAChangelog.Coverage.Tests.ps1
+++ b/tests/KeepAChangelog.Coverage.Tests.ps1
@@ -198,6 +198,42 @@ Describe 'Private helper coverage' {
             $result | Should -BeNullOrEmpty
         }
     }
+
+    It 'returns the latest existing release date from the changelog body' {
+        InModuleScope KeepAChangelog {
+            $result = Get-KeepAChangelogLatestReleaseDate -Body @'
+## [Unreleased]
+
+## [1.1.0] - 2026-05-02
+
+## [1.0.0] - 2026-05-01
+'@
+
+            $result | Should -Be '2026-05-02'
+        }
+    }
+
+    It 'returns null when no released versions exist yet' {
+        InModuleScope KeepAChangelog {
+            $result = Get-KeepAChangelogLatestReleaseDate -Body @'
+## [Unreleased]
+
+### Added
+'@
+
+            $result | Should -BeNullOrEmpty
+        }
+    }
+
+    It 'allows first-release date ordering when no previous release exists' {
+        InModuleScope KeepAChangelog {
+            {
+                Assert-KeepAChangelogReleaseDateOrder -Body '## [Unreleased]' -Release ([pscustomobject]@{
+                    Date = '2026-05-03'
+                })
+            } | Should -Not -Throw
+        }
+    }
 }
 
 Describe 'Validation result edge cases' {

--- a/tests/KeepAChangelog.Tests.ps1
+++ b/tests/KeepAChangelog.Tests.ps1
@@ -1,5 +1,52 @@
 BeforeAll {
     & (Join-Path $PSScriptRoot '..' 'scripts' 'build' 'ci' 'Import-BuiltCiModule.ps1') | Out-Null
+    $script:InitializeTestChangelog = {
+        param(
+            [Parameter(Mandatory)]
+            [string]$Path,
+            [string]$PreviousReleaseReference
+        )
+
+        $parameters = @{
+            Path          = $Path
+            RepositoryUrl = 'https://github.com/example/repo'
+            Force         = $true
+        }
+
+        if (-not [string]::IsNullOrWhiteSpace($PreviousReleaseReference)) {
+            $parameters.PreviousReleaseReference = $PreviousReleaseReference
+        }
+
+        Initialize-KeepAChangelogFile @parameters | Out-Null
+    }
+
+    $script:SetReleaseReadyChangelog = {
+        param(
+            [Parameter(Mandatory)]
+            [string]$Path,
+            [Parameter(Mandatory)]
+            [pscustomobject]$LatestRelease
+        )
+
+        @"
+# Changelog
+
+## [Unreleased]
+
+### Fixed
+
+- Fixed CLI parsing.
+
+## [$($LatestRelease.Version)] - $($LatestRelease.Date)
+
+### Added
+
+$($LatestRelease.Note)
+
+[Unreleased]: https://github.com/example/repo/compare/$($LatestRelease.Version)...HEAD
+[$($LatestRelease.Version)]: https://github.com/example/repo/compare/$($LatestRelease.PreviousVersion)...$($LatestRelease.Version)
+"@ | Set-Content -LiteralPath $Path -Encoding utf8
+    }
 }
 
 Describe 'Initialize-KeepAChangelogFile' {
@@ -53,33 +100,31 @@ Describe 'Initialize-KeepAChangelogFile' {
 }
 
 Describe 'Test-KeepAChangelogFile' {
-    It 'returns a valid result for a generated changelog file' {
-        $path = Join-Path $TestDrive 'CHANGELOG.md'
+    It 'returns a valid result for initialized changelog variants' {
+        $caseList = @(
+            @{
+                PreviousReleaseReference = '1.0.0'
+                ExpectedReference        = '1.0.0'
+            }
+            @{
+                PreviousReleaseReference = $null
+                ExpectedReference        = $null
+            }
+        )
 
-        Initialize-KeepAChangelogFile `
-            -Path $path `
-            -RepositoryUrl 'https://github.com/example/repo' `
-            -PreviousReleaseReference '1.0.0' `
-            -Force | Out-Null
+        foreach ($case in $caseList) {
+            $path = Join-Path $TestDrive "CHANGELOG-$($case.ExpectedReference ?? 'new').md"
+            & $script:InitializeTestChangelog -Path $path -PreviousReleaseReference $case.PreviousReleaseReference
+            $result = Test-KeepAChangelogFile -Path $path
 
-        $result = Test-KeepAChangelogFile -Path $path
+            $result.IsValid | Should -BeTrue
+            if ($null -eq $case.ExpectedReference) {
+                $result.PreviousReleaseReference | Should -BeNullOrEmpty
+                continue
+            }
 
-        $result.IsValid | Should -BeTrue
-        $result.PreviousReleaseReference | Should -Be '1.0.0'
-    }
-
-    It 'returns a valid result for a brand-new changelog without footer links' {
-        $path = Join-Path $TestDrive 'CHANGELOG.md'
-
-        Initialize-KeepAChangelogFile `
-            -Path $path `
-            -RepositoryUrl 'https://github.com/example/repo' `
-            -Force | Out-Null
-
-        $result = Test-KeepAChangelogFile -Path $path
-
-        $result.IsValid | Should -BeTrue
-        $result.PreviousReleaseReference | Should -BeNullOrEmpty
+            $result.PreviousReleaseReference | Should -Be $case.ExpectedReference
+        }
     }
 
     It 'reports a missing Unreleased section as invalid' {
@@ -329,16 +374,75 @@ Describe 'Move-UnreleasedChangelog' {
         $path = Join-Path $TestDrive 'CHANGELOG.md'
         $currentDate = Get-Date -Format 'yyyy-MM-dd'
 
-        Initialize-KeepAChangelogFile `
-            -Path $path `
-            -RepositoryUrl 'https://github.com/example/repo' `
-            -PreviousReleaseReference '1.0.0' `
-            -Force | Out-Null
+        & $script:InitializeTestChangelog -Path $path -PreviousReleaseReference '1.0.0'
 
         $result = Move-UnreleasedChangelog -Path $path -Version '1.6.0'
 
         $result.Release.Tag | Should -Be '1.6.0'
         $result.Release.Date | Should -Be $currentDate
+    }
+
+    It 'enforces release date ordering against the latest existing release' {
+        $caseList = @(
+            @{
+                Name             = 'earlier date'
+                ReleaseDate      = '2026-05-01'
+                ExpectedMessage  = "Release.Date '2026-05-01' cannot be earlier than latest existing release date '2026-05-02'."
+                ShouldThrow      = $true
+            }
+            @{
+                Name             = 'equal date'
+                ReleaseDate      = '2026-05-02'
+                ExpectedDate     = '2026-05-02'
+                ShouldThrow      = $false
+            }
+        )
+
+        foreach ($case in $caseList) {
+            $path = Join-Path $TestDrive "CHANGELOG-$($case.Name -replace ' ', '-').md"
+            & $script:SetReleaseReadyChangelog `
+                -Path $path `
+                -LatestRelease ([pscustomobject]@{
+                    Version         = '1.5.0'
+                    Date            = '2026-05-02'
+                    PreviousVersion = '1.4.0'
+                    Note            = '- Previous release notes.'
+                })
+
+            if ($case.ShouldThrow) {
+                {
+                    Move-UnreleasedChangelog -Path $path -Version '1.6.0' -Date $case.ReleaseDate
+                } | Should -Throw $case.ExpectedMessage
+                continue
+            }
+
+            $result = Move-UnreleasedChangelog -Path $path -Version '1.6.0' -Date $case.ReleaseDate
+            $result.Release.Date | Should -Be $case.ExpectedDate
+        }
+    }
+
+    It 'rejects the resolved current date when it is earlier than the latest existing release date' {
+        $path = Join-Path $TestDrive 'CHANGELOG.md'
+        $currentDate = Get-Date -Format 'yyyy-MM-dd'
+        $errorMessage = $null
+
+        & $script:SetReleaseReadyChangelog `
+            -Path $path `
+            -LatestRelease ([pscustomobject]@{
+                Version         = '9.9.9'
+                Date            = '2999-01-01'
+                PreviousVersion = '9.9.8'
+                Note            = '- Future release placeholder.'
+            })
+
+        try {
+            Move-UnreleasedChangelog -Path $path -Version '10.0.0'
+        }
+        catch {
+            $errorMessage = $_.Exception.Message
+        }
+
+        $errorMessage | Should -Be "Release.Date '$currentDate' cannot be earlier than latest existing release date '2999-01-01'."
     }
 
     It 'rejects an explicit Date with the wrong format' {


### PR DESCRIPTION
Summary

 - Added chronological release-date validation to Move-UnreleasedChangelog, so a new release cannot be created with a date earlier than the latest existing release date in CHANGELOG.md.
 - This was needed because the command already validated date format, but it could still create a changelog timeline that moved backward in time.
 - The new guard is applied in the release-resolution path, so it covers both explicit -Date values and the default current-date behavior. First releases still skip the chronology check, and same-day releases are still allowed.
 - Follow-up for the release-date validation discussion.

Affected area

 - [ ]  nova CLI or command routing
 - [X]  Public PowerShell cmdlet behavior
 - [ ]  Scaffolding or project.json handling
 - [ ]  Build, test, analyzer, coverage, or CI helper flow
 - [ ]  Package, raw upload, or package metadata workflow
 - [ ]  Publish, release, semantic-release, or GitHub Actions automation
 - [ ]  Self-update or notification preference behavior
 - [ ]  Contributor documentation (README.md, CONTRIBUTING.md, repository workflow docs)
 - [ ]  End-user docs (docs/*.html)
 - [ ]  Command help (docs/NovaModuleTools/en-US/*.md)
 - [ ]  src/resources/example/
 - [ ]  Dependency or manifest changes (package.json, workflow dependencies, release tooling)
 - [ ]  Security-sensitive change
 - [ ]  Documentation-only change
 - [X]  Other

Review guidance

Start with the release-resolution path:

 1. src/private/release/Assert-KeepAChangelogReleaseDateOrder.ps1
 2. src/private/release/Resolve-KeepAChangelogReleaseData.ps1

Then review the coverage and behavior tests in:

 - tests/KeepAChangelog.Tests.ps1
 - tests/KeepAChangelog.Coverage.Tests.ps1

Main points to review:

 - latest existing release date extraction
 - rejection of back-dated releases
 - allowance for first releases and same-day releases
 - coverage of omitted -Date using the resolved current date

Trade-offs / limitations:

 - The guard compares against the latest release date already present in the changelog, not semantic version ordering.
 - It assumes existing release headings already follow the validated ## [<version>] - <date> format.

Validation

 - [X]  Invoke-NovaBuild
 - [X]  Test-NovaBuild
 - [X]  ./scripts/build/Invoke-ScriptAnalyzerCI.ps1
 - [X]  ./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1
 - [ ]  Targeted Nova workflow validated (% nova build, % nova test, % nova merge, % nova deploy,
 % nova publish,
 % nova release, % nova update, % nova notification, or % nova init as relevant)
 - [ ]  Docs/example only; executable validation not needed

Validation notes:

 Ran:
 - Import-Module NovaModuleTools -ErrorAction Stop; Invoke-NovaBuild; Test-NovaBuild
 - ./scripts/build/Invoke-ScriptAnalyzerCI.ps1
 - ./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1 -OutputDirectory ./artifacts
 
 Result:
 - Build passed
 - Pester passed: 44 tests, 0 failed
 - CI helper passed and refreshed coverage artifacts
 - ScriptAnalyzer still reports the same 4 pre-existing warnings already present in the repo baseline; no new warnings were introduced
 
 Additional safeguard:
 - CodeScene pre-commit Code Health safeguard passed after deduplicating the new tests

Documentation and release follow-up

 - [ ]  README.md reviewed and updated if contributor workflow, architecture, CI, release, or automation changed
 - [ ]  CONTRIBUTING.md reviewed and updated if contribution expectations or review guidance changed
 - [X]  CHANGELOG.md reviewed and updated if the change matters to users, maintainers, or contributors
 - [ ]  docs/NovaModuleTools/en-US/ help updated if a public command or CLI behavior changed
 - [ ]  docs/*.html updated if end-user workflows or examples changed
 - [ ]  src/resources/example/ reviewed and updated if the real-world project layout, package model, or upload workflow
 changed
 - [ ]  No documentation, changelog, or example updates were needed

Maintainability, compatibility, and risk

 - [X]  Code Health / maintainability impact considered
 - [X]  No breaking change
 - [ ]  Breaking change
 - [ ]  Security-sensitive change
 - [ ]  CI, workflow, or release-pipeline impact
 - [ ]  Dependency-review impact

Risk, rollout, or rollback notes:

 Low-risk behavior change.
 
 This only tightens Move-UnreleasedChangelog validation and prevents invalid backward-dated releases.
 Existing valid release flows still work, including:
 - first release with no prior release date
 - same-day release dates
 - resolved current-date releases when chronology is valid
 
 Rollback is straightforward:
 - revert Assert-KeepAChangelogReleaseDateOrder.ps1
 - remove the call from Resolve-KeepAChangelogReleaseData.ps1
 - revert the related tests and changelog entry