### PR TITLE
#3 feat: report module version in cmdlet output and CI logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `Get-KeepAChangelogVersion` and included `KeepAChangelogVersion` in `Move-UnreleasedChangelog` output so CI logs and bug reports show which module version produced the result.
+
 ### Changed
 
 - Reworked `README.md` into a maintainer guide that explains the repository layout, local quality flow, CI/CD workflows, ScriptAnalyzer usage, CodeScene usage, release automation, and documentation ownership for the upcoming `1.0.0` release line.

--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ The public commands currently shipped by the module are:
 - `Initialize-KeepAChangelogFile`
 - `Test-KeepAChangelogFile`
 - `Move-UnreleasedChangelog`
+- `Get-KeepAChangelogVersion`
 - `Convert-ChangelogReleaseNotesToTagMessage`
 
 End-user usage belongs in the GitHub Pages guide. Keep the `README.md` focused on repository maintenance and release stewardship.

--- a/docs/KeepAChangelog/en-US/Get-KeepAChangelogVersion.md
+++ b/docs/KeepAChangelog/en-US/Get-KeepAChangelogVersion.md
@@ -1,0 +1,50 @@
+---
+document type: cmdlet
+external help file: KeepAChangelog-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: KeepAChangelog
+ms.date: 05/05/2026
+PlatyPS schema version: 2024-05-01
+title: Get-KeepAChangelogVersion
+---
+
+# Get-KeepAChangelogVersion
+
+## SYNOPSIS
+
+Returns the loaded KeepAChangelog module version.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```text
+PS> Get-KeepAChangelogVersion [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+`Get-KeepAChangelogVersion` returns the version of the currently loaded `KeepAChangelog`
+module.
+
+Use it in CI logs or local troubleshooting when you need to confirm which module version
+produced a release or validation result.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```text
+PS> Get-KeepAChangelogVersion
+```
+
+Returns the version string for the loaded `KeepAChangelog` module.
+
+## PARAMETERS
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, -WarningVariable.

--- a/docs/KeepAChangelog/en-US/KeepAChangelog.md
+++ b/docs/KeepAChangelog/en-US/KeepAChangelog.md
@@ -38,6 +38,10 @@ Validates that a changelog contains the required `## [Unreleased]` section, refe
 
 Moves the current `Unreleased` content into a versioned release section and updates compare links.
 
+### `PS> Get-KeepAChangelogVersion`
+
+Returns the loaded `KeepAChangelog` module version for troubleshooting and CI logging.
+
 ### `PS> Convert-ChangelogReleaseNotesToTagMessage`
 
 Converts markdown release notes into a trimmed plain-text tag message.

--- a/docs/KeepAChangelog/en-US/Move-UnreleasedChangelog.md
+++ b/docs/KeepAChangelog/en-US/Move-UnreleasedChangelog.md
@@ -40,6 +40,9 @@ The command:
 
 If the changelog has no footer yet because it started as a brand-new project, pass `-RepositoryUrl` on the first release so the footer links can be created.
 
+The returned object also includes `KeepAChangelogVersion` so CI logs and troubleshooting output
+can show which module version produced the release data.
+
 ## EXAMPLES
 
 ### EXAMPLE 1

--- a/docs/index.html
+++ b/docs/index.html
@@ -153,6 +153,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
             <li><code>Initialize-KeepAChangelogFile</code> creates a new changelog template.</li>
             <li><code>Test-KeepAChangelogFile</code> validates a changelog and returns the validation result.</li>
             <li><code>Move-UnreleasedChangelog</code> promotes the current unreleased notes into a release section.</li>
+            <li><code>Get-KeepAChangelogVersion</code> returns the loaded module version for CI logs and troubleshooting.</li>
             <li><code>Convert-ChangelogReleaseNotesToTagMessage</code> turns release notes into a tag-friendly plain-text message.</li>
           </ul>
         </div>
@@ -258,6 +259,18 @@ Install-PSResource -Name KeepAChangelog</code></pre>
 $result.IsValid
 $result.Errors</code></pre>
 
+          <h4 id="version-command">
+            <a aria-hidden="true" class="anchor" href="#version-command"></a>
+            Show the loaded module version
+          </h4>
+
+          <p>
+            Print the currently loaded <code>KeepAChangelog</code> version when you need CI output
+            or local debugging logs to show exactly which module build produced the result.
+          </p>
+
+          <pre><code>Get-KeepAChangelogVersion</code></pre>
+
           <h4 id="release-command">
             <a aria-hidden="true" class="anchor" href="#release-command"></a>
             Move unreleased notes into a release
@@ -317,6 +330,7 @@ Convert-ChangelogReleaseNotesToTagMessage -ReleaseNotes $releaseNotes</code></pr
 
           <ul>
             <li><code>Release.Version</code>, <code>Release.Date</code>, and <code>Release.Tag</code></li>
+            <li><code>KeepAChangelogVersion</code> for the module version that produced the release result</li>
             <li><code>ReleaseNotesBody</code> and <code>TagMessageText</code></li>
             <li><code>UpdatedUnreleasedLink</code> and <code>NewReleaseCompareLink</code></li>
             <li><code>UpdatedText</code> for the rewritten changelog content</li>

--- a/src/private/shared/Get-KeepAChangelogModuleVersion.ps1
+++ b/src/private/shared/Get-KeepAChangelogModuleVersion.ps1
@@ -1,0 +1,6 @@
+function Get-KeepAChangelogModuleVersion {
+    [CmdletBinding()]
+    param()
+
+    return $ExecutionContext.SessionState.Module.Version.ToString()
+}

--- a/src/public/Get-KeepAChangelogVersion.ps1
+++ b/src/public/Get-KeepAChangelogVersion.ps1
@@ -1,0 +1,7 @@
+function Get-KeepAChangelogVersion {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param()
+
+    return Get-KeepAChangelogModuleVersion
+}

--- a/src/public/Move-UnreleasedChangelog.ps1
+++ b/src/public/Move-UnreleasedChangelog.ps1
@@ -29,6 +29,7 @@ function Move-UnreleasedChangelog {
 
     $text = Get-Content -LiteralPath $Path -Raw
     $result = Resolve-KeepAChangelogReleaseData -Text $text -Release $release -RepositoryUrl $RepositoryUrl
+    $result | Add-Member -NotePropertyName KeepAChangelogVersion -NotePropertyValue (Get-KeepAChangelogModuleVersion) -Force
     $targetVersion = $result.Release.Version
 
     if (-not $PSCmdlet.ShouldProcess($Path, "Promote [Unreleased] to [$targetVersion]")) {

--- a/tests/KeepAChangelog.Coverage.Tests.ps1
+++ b/tests/KeepAChangelog.Coverage.Tests.ps1
@@ -68,11 +68,18 @@ Describe 'Public command guard clauses' {
         $after = Get-Content -LiteralPath $path -Raw
 
         $result.Release.Version | Should -Be '1.6.0'
+        $result.KeepAChangelogVersion | Should -Be (Get-KeepAChangelogVersion)
         $after | Should -Be $before
     }
 }
 
 Describe 'Private helper coverage' {
+    It 'returns the loaded module version through the public version cmdlet' {
+        $result = Get-KeepAChangelogVersion
+
+        $result | Should -Be ((Get-Module KeepAChangelog).Version.ToString())
+    }
+
     It 'validates required release fields' {
         InModuleScope KeepAChangelog {
             $caseList = @(
@@ -232,6 +239,14 @@ Describe 'Private helper coverage' {
                     Date = '2026-05-03'
                 })
             } | Should -Not -Throw
+        }
+    }
+
+    It 'returns the current module version from the shared helper' {
+        InModuleScope KeepAChangelog {
+            $result = Get-KeepAChangelogModuleVersion
+
+            $result | Should -Be ((Get-Module KeepAChangelog).Version.ToString())
         }
     }
 }

--- a/tests/KeepAChangelog.Tests.ps1
+++ b/tests/KeepAChangelog.Tests.ps1
@@ -99,6 +99,14 @@ Describe 'Initialize-KeepAChangelogFile' {
     }
 }
 
+Describe 'Get-KeepAChangelogVersion' {
+    It 'returns the loaded KeepAChangelog module version' {
+        $result = Get-KeepAChangelogVersion
+
+        $result | Should -Be ((Get-Module KeepAChangelog).Version.ToString())
+    }
+}
+
 Describe 'Test-KeepAChangelogFile' {
     It 'returns a valid result for initialized changelog variants' {
         $caseList = @(
@@ -227,6 +235,7 @@ Describe 'Move-UnreleasedChangelog' {
         $updated | Should -Match '(?s)## \[Unreleased\]\s+### Added\s+### Fixed'
         $updated | Should -Match '\[Unreleased\]: https://github\.com/example/repo/compare/1\.6\.0\.\.\.HEAD'
         $updated | Should -Match '\[1\.6\.0\]: https://github\.com/example/repo/compare/1\.5\.0\.\.\.1\.6\.0'
+        $result.KeepAChangelogVersion | Should -Be (Get-KeepAChangelogVersion)
     }
 
     It 'supports simple unreleased notes without subsection headings' {


### PR DESCRIPTION
Summary

 - Added a new public Get-KeepAChangelogVersion cmdlet that returns the currently loaded KeepAChangelog module version.
 - Extended Move-UnreleasedChangelog so its returned object now includes KeepAChangelogVersion.
 - This was needed to make CI logs and troubleshooting output self-describing, so users can immediately see which module version produced a release result or failure without adding custom logging.
 - Follow-up for the CI/version-reporting discussion.

Affected area

 - [ ]  nova CLI or command routing
 - [X]  Public PowerShell cmdlet behavior
 - [ ]  Scaffolding or project.json handling
 - [ ]  Build, test, analyzer, coverage, or CI helper flow
 - [ ]  Package, raw upload, or package metadata workflow
 - [ ]  Publish, release, semantic-release, or GitHub Actions automation
 - [ ]  Self-update or notification preference behavior
 - [X]  Contributor documentation (README.md, CONTRIBUTING.md, repository workflow docs)
 - [X]  End-user docs (docs/*.html)
 - [X]  Command help (docs/NovaModuleTools/en-US/*.md)
 - [ ]  src/resources/example/
 - [ ]  Dependency or manifest changes (package.json, workflow dependencies, release tooling)
 - [ ]  Security-sensitive change
 - [ ]  Documentation-only change
 - [X]  Other

Review guidance

Start with the public entry points:

 1. src/public/Get-KeepAChangelogVersion.ps1
 2. src/public/Move-UnreleasedChangelog.ps1

Then review the shared version source:

 - src/private/shared/Get-KeepAChangelogModuleVersion.ps1

Then the tests and docs:

 - tests/KeepAChangelog.Tests.ps1
 - tests/KeepAChangelog.Coverage.Tests.ps1
 - docs/KeepAChangelog/en-US/
 - docs/index.html
 - README.md

Trade-offs / limitations:

 - The reported version comes from the loaded module instance, not from project.json, which is intentional because the goal is to show the actual version used in CI/runtime.
 - If multiple module versions are installed side-by-side, the reported value reflects whichever version was imported into the current session.

Validation

 - [X]  Invoke-NovaBuild
 - [X]  Test-NovaBuild
 - [X]  ./scripts/build/Invoke-ScriptAnalyzerCI.ps1
 - [X]  ./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1
 - [ ]  Targeted Nova workflow validated (% nova build, % nova test, % nova merge, % nova deploy,
 % nova publish,
 % nova release, % nova update, % nova notification, or % nova init as relevant)
 - [ ]  Docs/example only; executable validation not needed

Validation notes:

 Ran:
 - Import-Module NovaModuleTools -ErrorAction Stop; Invoke-NovaBuild; Test-NovaBuild
 - ./scripts/build/Invoke-ScriptAnalyzerCI.ps1
 - ./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1 -OutputDirectory ./artifacts
 
 Result:
 - Build passed
 - Pester passed: 47 tests, 0 failed
 - CI helper passed and refreshed coverage artifacts
 - Code Health safeguard passed
 - ScriptAnalyzer still reports the same 4 pre-existing baseline warnings; no new warnings were introduced by this change
 
 Scenario exercised:
 - Queried module version directly through Get-KeepAChangelogVersion
 - Verified Move-UnreleasedChangelog includes KeepAChangelogVersion in its returned object, including WhatIf/result coverage

Documentation and release follow-up

 - [X]  README.md reviewed and updated if contributor workflow, architecture, CI, release, or automation changed
 - [ ]  CONTRIBUTING.md reviewed and updated if contribution expectations or review guidance changed
 - [X]  CHANGELOG.md reviewed and updated if the change matters to users, maintainers, or contributors
 - [X]  docs/NovaModuleTools/en-US/ help updated if a public command or CLI behavior changed
 - [X]  docs/*.html updated if end-user workflows or examples changed
 - [ ]  src/resources/example/ reviewed and updated if the real-world project layout, package model, or upload workflow
 changed
 - [ ]  No documentation, changelog, or example updates were needed

Maintainability, compatibility, and risk

 - [X]  Code Health / maintainability impact considered
 - [X]  No breaking change
 - [ ]  Breaking change
 - [ ]  Security-sensitive change
 - [ ]  CI, workflow, or release-pipeline impact
 - [ ]  Dependency-review impact

Risk, rollout, or rollback notes:

 Low risk and backward-compatible.
 
 This adds a new public cmdlet and one additional property on the Move-UnreleasedChangelog result object.
 Existing consumers that ignore extra properties continue to work unchanged.
 
 Rollback is straightforward:
 - remove src/public/Get-KeepAChangelogVersion.ps1
 - remove src/private/shared/Get-KeepAChangelogModuleVersion.ps1
 - remove KeepAChangelogVersion from Move-UnreleasedChangelog output
 - revert the related tests and docs