### PR TITLE
fix: accept yanked release headings in changelog validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- Fixed `Test-KeepAChangelogFile` so yanked release headings like `## [2.2.0] - 2026-05-06 [YANKED]` are accepted as valid Keep a Changelog release sections.
+
 ### Security
 
 ## [0.2.1] - 2026-05-06
@@ -63,4 +65,3 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 [0.2.0]: https://github.com/stiwicourage/KeepAChangelog/compare/0.1.2...0.2.0
 [0.1.2]: https://github.com/stiwicourage/KeepAChangelog/compare/0.1.1...0.1.2
 [0.1.1]: https://github.com/stiwicourage/KeepAChangelog/compare/103d84a...0.1.1
-

--- a/project.json
+++ b/project.json
@@ -1,7 +1,7 @@
 {
   "ProjectName": "KeepAChangelog",
   "Description": "PowerShell helpers for creating, validating, and releasing Keep a Changelog files.",
-  "Version": "0.2.1",
+  "Version": "0.2.2-preview",
   "Preamble": [
     "Set-StrictMode -Version Latest"
   ],

--- a/src/private/validation/Get-KeepAChangelogReleaseVersionList.ps1
+++ b/src/private/validation/Get-KeepAChangelogReleaseVersionList.ps1
@@ -17,8 +17,8 @@ function Get-KeepAChangelogReleaseVersionList {
         }
 
         $line = $releaseHeadingLine.Value.TrimEnd()
-        if ($line -notmatch '^## \[[^\]]+\] - \d{4}-\d{2}-\d{2}$') {
-            $ErrorList.Add("Release section '$line' must use '## [<version>] - <date>' format.")
+        if ($line -notmatch '^## \[[^\]]+\] - \d{4}-\d{2}-\d{2}( \[YANKED\])?$') {
+            $ErrorList.Add("Release section '$line' must use '## [<version>] - <date>' format, optionally followed by ' [YANKED]'.")
             continue
         }
 

--- a/tests/KeepAChangelog.Coverage.Tests.ps1
+++ b/tests/KeepAChangelog.Coverage.Tests.ps1
@@ -303,7 +303,32 @@ Describe 'Validation result edge cases' {
 [1.0.0]: https://github.com/example/repo/releases/tag/1.0.0
 '@
 
-            $result.Errors | Should -Contain "Release section '## [1.0.0]' must use '## [<version>] - <date>' format."
+            $result.Errors | Should -Contain "Release section '## [1.0.0]' must use '## [<version>] - <date>' format, optionally followed by ' [YANKED]'."
+        }
+    }
+
+    It 'accepts yanked release sections that follow the Keep a Changelog heading format' {
+        InModuleScope KeepAChangelog {
+            $result = Get-KeepAChangelogValidationResult -Text @'
+# Changelog
+
+## [Unreleased]
+
+### Added
+
+## [1.0.0] - 2026-04-30 [YANKED]
+
+### Fixed
+
+- Yanked because of a release regression.
+
+[Unreleased]: https://github.com/example/repo/compare/1.0.0...HEAD
+[1.0.0]: https://github.com/example/repo/releases/tag/1.0.0
+'@
+
+            $result.IsValid | Should -BeTrue
+            $result.Errors.Count | Should -Be 0
+            @($result.ReleaseVersions) | Should -Be @('1.0.0')
         }
     }
 

--- a/tests/KeepAChangelog.Tests.ps1
+++ b/tests/KeepAChangelog.Tests.ps1
@@ -180,6 +180,34 @@ Describe 'Test-KeepAChangelogFile' {
         $result.Errors | Should -Contain 'CHANGELOG.md must end with reference links once releases exist.'
     }
 
+    It 'accepts yanked release headings that follow the Keep a Changelog format' {
+        $path = Join-Path $TestDrive 'CHANGELOG-YANKED.md'
+
+        @'
+# Changelog
+
+## [Unreleased]
+
+### Added
+
+## [2.2.0] - 2026-05-06 [YANKED]
+
+### Fixed
+
+- Yanked because of a release regression.
+
+[Unreleased]: https://github.com/example/repo/compare/2.2.0...HEAD
+[2.2.0]: https://github.com/example/repo/releases/tag/2.2.0
+'@ | Set-Content -LiteralPath $path -Encoding utf8
+
+        $result = Test-KeepAChangelogFile -Path $path
+
+        $result.IsValid | Should -BeTrue
+        $result.Errors.Count | Should -Be 0
+        @($result.ReleaseVersions) | Should -Be @('2.2.0')
+        $result.PreviousReleaseReference | Should -Be '2.2.0'
+    }
+
     It 'throws the validation errors when ThrowOnError is used' {
         $path = Join-Path $TestDrive 'CHANGELOG.md'
         $errorMessage = $null


### PR DESCRIPTION
Summary

 - Updated changelog validation so Test-KeepAChangelogFile accepts yanked release headings in the Keep a Changelog form ## [<version>] - <date> [YANKED].
 - This was needed because the validator incorrectly rejected a valid Keep a Changelog heading, which blocked real use cases like marking NovaModuleTools
  2.2.0 as yanked.
 - Closes #18.

Affected area

 - [ ]  nova CLI or command routing
 - [X]  Public PowerShell cmdlet behavior
 - [ ]  Scaffolding or project.json handling
 - [ ]  Build, test, analyzer, coverage, or CI helper flow
 - [ ]  Package, raw upload, or package metadata workflow
 - [ ]  Publish, release, semantic-release, or GitHub Actions automation
 - [ ]  Self-update or notification preference behavior
 - [ ]  Contributor documentation (README.md, CONTRIBUTING.md, repository workflow docs)
 - [ ]  End-user docs (docs/*.html)
 - [ ]  Command help (docs/NovaModuleTools/en-US/*.md)
 - [ ]  src/resources/example/
 - [ ]  Dependency or manifest changes (package.json, workflow dependencies, release tooling)
 - [ ]  Security-sensitive change
 - [ ]  Documentation-only change
 - [X]  Other

Review guidance

 - Start with src/private/validation/Get-KeepAChangelogReleaseVersionList.ps1.
 - Main files changed:
  - src/private/validation/Get-KeepAChangelogReleaseVersionList.ps1
  - tests/KeepAChangelog.Tests.ps1
  - tests/KeepAChangelog.Coverage.Tests.ps1
  - CHANGELOG.md
 - Trade-off: the validator is now slightly more permissive by allowing the optional  [YANKED] suffix, but it still preserves the same version/date structure and duplicate-release 
checks.

Validation

 - [X]  Invoke-NovaBuild
 - [X]  Test-NovaBuild
 - [ ]  ./scripts/build/Invoke-ScriptAnalyzerCI.ps1
 - [ ]  ./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1
 - [ ]  Targeted Nova workflow validated (% nova build, % nova test, % nova merge, % nova deploy,
 % nova publish,
 % nova release, % nova update, % nova notification, or % nova init as relevant)
 - [ ]  Docs/example only; executable validation not needed

Validation notes:

 Invoke-NovaBuild
 Test-NovaBuild
 
 Added both private-helper and public-cmdlet regression coverage for:
 ## [<version>] - <date> [YANKED]
 
 CodeScene pre-commit safeguard also passed for the KeepAChangelog repo diff.

Documentation and release follow-up

 - [ ]  README.md reviewed and updated if contributor workflow, architecture, CI, release, or automation changed
 - [ ]  CONTRIBUTING.md reviewed and updated if contribution expectations or review guidance changed
 - [X]  CHANGELOG.md reviewed and updated if the change matters to users, maintainers, or contributors
 - [ ]  docs/NovaModuleTools/en-US/ help updated if a public command or CLI behavior changed
 - [ ]  docs/*.html updated if end-user workflows or examples changed
 - [ ]  src/resources/example/ reviewed and updated if the real-world project layout, package model, or upload workflow
 changed
 - [ ]  No documentation, changelog, or example updates were needed

Maintainability, compatibility, and risk

 - [X]  Code Health / maintainability impact considered
 - [X]  No breaking change
 - [ ]  Breaking change
 - [ ]  Security-sensitive change
 - [ ]  CI, workflow, or release-pipeline impact
 - [ ]  Dependency-review impact

Risk, rollout, or rollback notes:

 Compatibility impact is low: this only broadens changelog validation to accept a Keep a Changelog-compliant yanked heading format.
 
 Rollback is straightforward:
 - remove the optional ` [YANKED]` suffix from the release-heading regex
 - remove the two regression tests
 - revert the changelog note
 
 No migration steps are required for users. Existing non-yanked release headings continue to validate unchanged