### PR TITLE
Fix changelog validation and improve internal helper names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- Fixed `Test-KeepAChangelogFile` so changelogs with valid `Unreleased` and dated release headings can stay valid even when they intentionally omit footer reference links.
+- Fixed `Move-UnreleasedChangelog` so changelogs that intentionally omit footer reference links can still promote `Unreleased` notes without requiring `-RepositoryUrl`.
+
 ### Security
 
 ## [0.2.3] - 2026-05-07
@@ -74,4 +77,3 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 [0.2.0]: https://github.com/stiwicourage/KeepAChangelog/compare/0.1.2...0.2.0
 [0.1.2]: https://github.com/stiwicourage/KeepAChangelog/compare/0.1.1...0.1.2
 [0.1.1]: https://github.com/stiwicourage/KeepAChangelog/compare/103d84a...0.1.1
-

--- a/docs/KeepAChangelog/en-US/KeepAChangelog.md
+++ b/docs/KeepAChangelog/en-US/KeepAChangelog.md
@@ -20,7 +20,7 @@ KeepAChangelog helps you create, validate, and release changelog files that foll
 Use the module when you want a repeatable PowerShell workflow for:
 
 - creating a changelog template with `## [Unreleased]`
-- validating required compare links and release headings
+- validating optional compare links when present and release headings
 - promoting unreleased notes into a versioned release section
 - generating plain-text tag messages from markdown release notes
 
@@ -36,7 +36,7 @@ Validates that a changelog contains the required `## [Unreleased]` section, opti
 
 ### `PS> Move-UnreleasedChangelog`
 
-Moves the current `Unreleased` content into a versioned release section and updates compare links.
+Moves the current `Unreleased` content into a versioned release section and can update compare links when footer links are being maintained.
 
 ### `PS> Get-KeepAChangelogVersion`
 

--- a/docs/KeepAChangelog/en-US/Move-UnreleasedChangelog.md
+++ b/docs/KeepAChangelog/en-US/Move-UnreleasedChangelog.md
@@ -33,12 +33,12 @@ The command:
 2. removes empty `###` subsections from the new release notes
 3. inserts `## [<version>] - <date>` below `## [Unreleased]`
 4. clears `Unreleased` while keeping subsection headings
-5. updates the `[Unreleased]` compare link to `<tag>...HEAD`
-6. adds or updates the `[<version>]` release link from the previous release reference to the new tag
+5. updates the `[Unreleased]` compare link to `<tag>...HEAD` when a reference-link footer exists or `-RepositoryUrl` is supplied
+6. adds or updates the `[<version>]` release link from the previous release reference to the new tag when footer links are being maintained
 
 `-Version` is required. `-Date` is optional. When `-Date` is omitted, the current date is used. When `-Date` is provided, it must use `yyyy-MM-dd` format.
 
-If the changelog has no footer yet because it started as a brand-new project, pass `-RepositoryUrl` on the first release so the footer links can be created.
+If the changelog has no footer and you want footer links to be created or maintained, pass `-RepositoryUrl`. If you omit it, the release move still runs and the changelog stays without footer links.
 
 The returned object also includes `KeepAChangelogVersion` so CI logs and troubleshooting output
 can show which module version produced the release data.
@@ -77,7 +77,7 @@ Optional release date in `yyyy-MM-dd` format.
 
 ### -RepositoryUrl
 
-Optional repository base URL used to create footer links on the first release when the changelog has no `[Unreleased]` compare link yet.
+Optional repository base URL used to create or maintain footer links when the changelog has no `[Unreleased]` compare link yet.
 
 ### CommonParameters
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -107,7 +107,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
           </h3>
 
           <p>
-            The module keeps the <code>Unreleased</code> section, compare links, release headings,
+            The module keeps the <code>Unreleased</code> section, optional compare links, release headings,
             and release-note formatting consistent so you do not have to.
           </p>
 
@@ -140,7 +140,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
             <li>Include an optional <code>[Unreleased]</code> compare link footer when a previous release reference exists.</li>
             <li>Validate an existing changelog and return structured errors when the file does not follow the expected format.</li>
             <li>Move unreleased notes into a new release section and clear the unreleased body for the next cycle.</li>
-            <li>Update compare links and release links automatically as part of the release move.</li>
+            <li>Update compare links and release links automatically as part of the release move when footer links are being maintained.</li>
             <li>Convert markdown release notes into a plain-text tag message for git tags or release automation.</li>
           </ul>
 
@@ -284,7 +284,7 @@ $result.Errors</code></pre>
 
           <p>
             Promote the current <code>## [Unreleased]</code> notes into a new versioned release
-            section and update the compare links.
+            section and optionally update the compare links.
           </p>
 
           <pre><code>Move-UnreleasedChangelog `

--- a/project.json
+++ b/project.json
@@ -1,7 +1,7 @@
 {
   "ProjectName": "KeepAChangelog",
   "Description": "PowerShell helpers for creating, validating, and releasing Keep a Changelog files.",
-  "Version": "0.2.3",
+  "Version": "0.2.4-preview",
   "Preamble": [
     "Set-StrictMode -Version Latest"
   ],

--- a/src/private/release/Get-UpdatedChangelogReferenceFooter.ps1
+++ b/src/private/release/Get-UpdatedChangelogReferenceFooter.ps1
@@ -93,6 +93,20 @@ function Get-UpdatedChangelogReferenceFooter {
         [pscustomobject]$Context
     )
 
+    $shouldWriteReferenceFooter = $true
+    if ($Context.PSObject.Properties.Name -contains 'ShouldWriteReferenceFooter') {
+        $shouldWriteReferenceFooter = [bool]$Context.ShouldWriteReferenceFooter
+    }
+
+    if (-not $shouldWriteReferenceFooter) {
+        return [pscustomobject]@{
+            Footer               = ''
+            UpdatedUnreleasedLink = $null
+            NewReleaseCompareLink = $null
+            NewReleaseLink        = $null
+        }
+    }
+
     $referenceLinkData = Get-ChangelogReferenceLinkData -Footer $Footer
     $orderedLabelList = $referenceLinkData.OrderedLabelList
     $linkMap = $referenceLinkData.LinkMap

--- a/src/private/release/Resolve-KeepAChangelogReleaseData.ps1
+++ b/src/private/release/Resolve-KeepAChangelogReleaseData.ps1
@@ -30,11 +30,19 @@ function Get-KeepAChangelogRepositoryContext {
     }
 
     $unreleasedCompareLinkPrefix = $Validation.UnreleasedCompareLinkPrefix
-    if ([string]::IsNullOrWhiteSpace($unreleasedCompareLinkPrefix)) {
-        if ([string]::IsNullOrWhiteSpace($normalizedRepositoryUrl)) {
-            throw 'RepositoryUrl is required for the first release when CHANGELOG.md has no [Unreleased] compare link.'
-        }
+    $shouldWriteReferenceFooter = (-not [string]::IsNullOrWhiteSpace($unreleasedCompareLinkPrefix)) -or `
+        (-not [string]::IsNullOrWhiteSpace($normalizedRepositoryUrl))
 
+    if (-not $shouldWriteReferenceFooter) {
+        return [pscustomobject]@{
+            RepositoryUrl               = $null
+            UnreleasedCompareLinkPrefix = $null
+            PreviousReleaseReference    = $null
+            ShouldWriteReferenceFooter  = $false
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($unreleasedCompareLinkPrefix)) {
         $unreleasedCompareLinkPrefix = "$normalizedRepositoryUrl/compare/"
     }
 
@@ -51,6 +59,7 @@ function Get-KeepAChangelogRepositoryContext {
         RepositoryUrl               = $normalizedRepositoryUrl
         UnreleasedCompareLinkPrefix = $unreleasedCompareLinkPrefix
         PreviousReleaseReference    = $previousReleaseReference
+        ShouldWriteReferenceFooter  = $true
     }
 }
 
@@ -135,7 +144,14 @@ function Resolve-KeepAChangelogReleaseData {
         -Footer $parts.Footer `
         -Release $normalizedRelease `
         -Context $repositoryContext
-    $updatedText = ($updatedBody + "`n`n" + $updatedFooterData.Footer).TrimEnd() + "`n"
+    $updatedText = @(
+        $updatedBody
+        $updatedFooterData.Footer
+    ) |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+        ForEach-Object { $_.TrimEnd() } |
+        Join-String -Separator "`n`n"
+    $updatedText = $updatedText.TrimEnd() + "`n"
 
     return [pscustomobject]@{
         Release                     = $normalizedRelease

--- a/tests/KeepAChangelog.Coverage.Tests.ps1
+++ b/tests/KeepAChangelog.Coverage.Tests.ps1
@@ -454,4 +454,23 @@ Describe 'Validation result edge cases' {
             $result.Errors | Should -Contain 'CHANGELOG.md must contain exactly one [Unreleased] compare link.'
         }
     }
+
+    It 'returns an empty footer update when no footer links should be written' {
+        InModuleScope KeepAChangelog {
+            $result = Get-UpdatedChangelogReferenceFooter `
+                -Footer '' `
+                -Release ([pscustomobject]@{
+                    Tag     = '1.0.0'
+                    Version = '1.0.0'
+                }) `
+                -Context ([pscustomobject]@{
+                    ShouldWriteReferenceFooter = $false
+                })
+
+            $result.Footer | Should -Be ''
+            $result.UpdatedUnreleasedLink | Should -BeNullOrEmpty
+            $result.NewReleaseCompareLink | Should -BeNullOrEmpty
+            $result.NewReleaseLink | Should -BeNullOrEmpty
+        }
+    }
 }

--- a/tests/KeepAChangelog.Tests.ps1
+++ b/tests/KeepAChangelog.Tests.ps1
@@ -387,9 +387,8 @@ Describe 'Move-UnreleasedChangelog' {
         $updated | Should -Match '\[1\.0\.0\]: https://github\.com/example/repo/releases/tag/1\.0\.0'
     }
 
-    It 'requires RepositoryUrl for the first release when the changelog has no compare link yet' {
+    It 'keeps footer links omitted when RepositoryUrl is omitted on the first release' {
         $path = Join-Path $TestDrive 'CHANGELOG.md'
-        $errorMessage = $null
 
         @'
 # Changelog
@@ -401,13 +400,44 @@ Describe 'Move-UnreleasedChangelog' {
 - Initial release notes.
 '@ | Set-Content -LiteralPath $path -Encoding utf8
 
-        try {
-            Move-UnreleasedChangelog -Path $path -Version '1.0.0' -Date '2026-05-01'
-        } catch {
-            $errorMessage = $_.Exception.Message
-        }
+        $result = Move-UnreleasedChangelog -Path $path -Version '1.0.0' -Date '2026-05-01'
+        $updated = Get-Content -LiteralPath $path -Raw
 
-        $errorMessage | Should -Be 'RepositoryUrl is required for the first release when CHANGELOG.md has no [Unreleased] compare link.'
+        $result.UpdatedUnreleasedLink | Should -BeNullOrEmpty
+        $result.NewReleaseCompareLink | Should -BeNullOrEmpty
+        $result.NewReleaseLink | Should -BeNullOrEmpty
+        $updated | Should -Not -Match '(?m)^\[Unreleased\]:'
+        $updated | Should -Not -Match '(?m)^\[1\.0\.0\]:'
+    }
+
+    It 'keeps footer links omitted when releasing a changelog that already has releases but no footer' {
+        $path = Join-Path $TestDrive 'CHANGELOG.md'
+
+        @'
+# Changelog
+
+## [Unreleased]
+
+### Fixed
+
+- Follow-up release notes.
+
+## [1.5.0] - 2026-04-10
+
+### Added
+
+- Previous release notes.
+'@ | Set-Content -LiteralPath $path -Encoding utf8
+
+        $result = Move-UnreleasedChangelog -Path $path -Version '1.6.0' -Date '2026-04-30'
+        $updated = Get-Content -LiteralPath $path -Raw
+
+        $result.UpdatedUnreleasedLink | Should -BeNullOrEmpty
+        $result.NewReleaseCompareLink | Should -BeNullOrEmpty
+        $result.NewReleaseLink | Should -BeNullOrEmpty
+        $updated | Should -Match '## \[1\.6\.0\] - 2026-04-30'
+        $updated | Should -Not -Match '(?m)^\[Unreleased\]:'
+        $updated | Should -Not -Match '(?m)^\[1\.6\.0\]:'
     }
 
     It 'uses the version as the tag and the current date when Date is omitted' {


### PR DESCRIPTION
## Summary
 
 - `Test-KeepAChangelogFile` now accepts changelogs that intentionally omit footer reference links when the `## [Unreleased]` section and release headings are otherwise valid.
 - `Move-UnreleasedChangelog` now supports the same no-footer workflow: if a changelog has no footer links and `-RepositoryUrl` is omitted, the release move still succeeds and keeps the footer absent. If `-RepositoryUrl` is supplied, footer links are still created or maintained.
 - This change was needed because the previous behavior rejected valid no-footer changelogs during validation and later failed release automation with `RepositoryUrl is required for the first release when CHANGELOG.md has no [Unreleased] compare link.`
 - Internal helper functions were also renamed to satisfy ScriptAnalyzer so the full `run.ps1` quality gate passes cleanly.
 - Closes #24
 
 ## Affected area
 
 - [ ] `nova` CLI or command routing
 - [x] Public PowerShell cmdlet behavior
 - [ ] Scaffolding or `project.json` handling
 - [x] Build, test, analyzer, coverage, or CI helper flow
 - [ ] Package, raw upload, or package metadata workflow
 - [ ] Publish, release, semantic-release, or GitHub Actions automation
 - [ ] Self-update or notification preference behavior
 - [ ] Contributor documentation (`README.md`, `CONTRIBUTING.md`, repository workflow docs)
 - [x] End-user docs (`docs/*.html`)
 - [x] Command help (`docs/NovaModuleTools/en-US/*.md`)
 - [ ] `src/resources/example/`
 - [ ] Dependency or manifest changes (`package.json`, workflow dependencies, release tooling)
 - [ ] Security-sensitive change
 - [ ] Documentation-only change
 - [ ] Other
 
 ## Review guidance
 
 - Start with `src/private/validation/Get-KeepAChangelogValidationResult.ps1` for the validation change that stops requiring footer links.
 - Then review `src/private/release/Resolve-KeepAChangelogReleaseData.ps1` and `src/private/release/Get-UpdatedChangelogReferenceFooter.ps1` for the release-path change that keeps footer links optional unless they are already present or `-RepositoryUrl` is provided.
 - Review the regression coverage in:
   - `tests/KeepAChangelog.Tests.ps1`
   - `tests/KeepAChangelog.Coverage.Tests.ps1`
 - The ScriptAnalyzer cleanup is internal-only and limited to helper renames in:
   - `src/private/initialize/`
   - `src/private/release/`
   - matching call sites in `src/public/`
 - Main files changed:
   - `src/private/validation/`
   - `src/private/release/`
   - `src/private/initialize/`
   - `src/public/`
   - `tests/`
   - `docs/KeepAChangelog/en-US/`
   - `docs/index.html`
   - `CHANGELOG.md`
 - Trade-off: this makes the release flow more permissive for no-footer changelogs, which matches the updated validator behavior. Public command behavior changes, but there is no breaking API change.
 
 ## Validation
 
 - [x] `Invoke-NovaBuild`
 - [x] `Test-NovaBuild`
 - [x] `./scripts/build/Invoke-ScriptAnalyzerCI.ps1`
 - [ ] `./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1`
 - [ ] Targeted Nova workflow validated (`% nova build`, `% nova test`, `% nova merge`, `% nova deploy`, `% nova publish`, `% nova release`, `% nova update`, `% nova notification`, or `% nova init` as relevant)
 - [ ] Docs/example only; executable validation not needed
 
 Validation notes:
 
 ```text
 Ran:
 - ./run.ps1
 - Invoke-NovaBuild
 - Test-NovaBuild
 - ./scripts/build/Invoke-ScriptAnalyzerCI.ps1
 
 Result:
 - PSScriptAnalyzer: no findings
 - Pester: 55 passed, 0 failed
 - CodeScene pre-commit safeguard: passed
 
 The release scenario exercised was:
 - changelog with footer links -> release still updates links
 - changelog without footer links and no RepositoryUrl -> release succeeds and keeps footer absent
 - changelog without footer links and RepositoryUrl -> release creates footer links
 ```

Documentation and release follow-up

 - [ ]  README.md reviewed and updated if contributor workflow, architecture, CI, release, or automation changed
 - [ ]  CONTRIBUTING.md reviewed and updated if contribution expectations or review guidance changed
 - [X]  CHANGELOG.md reviewed and updated if the change matters to users, maintainers, or contributors
 - [X]  docs/NovaModuleTools/en-US/ help updated if a public command or CLI behavior changed
 - [X]  docs/*.html updated if end-user workflows or examples changed
 - [ ]  src/resources/example/ reviewed and updated if the real-world project layout, package model, or upload workflow changed
 - [ ]  No documentation, changelog, or example updates were needed

Maintainability, compatibility, and risk

 - [X]  Code Health / maintainability impact considered
 - [X]  No breaking change
 - [ ]  Breaking change
 - [ ]  Security-sensitive change
 - [X]  CI, workflow, or release-pipeline impact
 - [ ]  Dependency-review impact

Risk, rollout, or rollback notes:

 Low risk.
 
 The validation and release-path changes are permissive and remove false negatives / unnecessary release failures for
 changelogs that intentionally omit footer reference links.
 
 Footer-link maintenance still works as before when links already exist or when RepositoryUrl is provided.
 The helper renames are internal-only and were made to satisfy ScriptAnalyzer so the full run.ps1 quality gate passes.
 
 Rollback is straightforward because there are no dependency changes or public API shape changes.

 [!IMPORTANT] Do not use a public pull request to disclose a vulnerability before coordinated handling. Use the private reporting path in SECURITY.md for new security issues.
