### PR TITLE
Enhance changelog footer handling and update documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,73 +6,74 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+
 ### Added
 
+
 ### Changed
+
 
 ### Deprecated
 
+
 ### Removed
 
+
 ### Fixed
+- Fixed footer parsing so `Test-KeepAChangelogFile` and `Move-UnreleasedChangelog` accept valid reference-link footers even when blank lines separate the links.
+
 
 ### Security
 
+
 ## [0.2.4] - 2026-05-07
-
 ### Fixed
-
 - Fixed `Test-KeepAChangelogFile` so changelogs with valid `Unreleased` and dated release headings can stay valid even when they intentionally omit footer reference links.
 - Fixed `Move-UnreleasedChangelog` so changelogs that intentionally omit footer reference links can still promote `Unreleased` notes without requiring `-RepositoryUrl`.
 
+
 ## [0.2.3] - 2026-05-07
-
 ## [0.2.2] - 2026-05-07
-
 ### Fixed
-
 - Fixed `Test-KeepAChangelogFile` so changelogs with valid `Unreleased` and dated release headings can stay valid even when they intentionally omit footer reference links.
 - Fixed `Test-KeepAChangelogFile` so yanked release headings like `## [2.2.0] - 2026-05-06 [YANKED]` are accepted as valid Keep a Changelog release sections.
 
+
 ## [0.2.1] - 2026-05-06
-
 ### Fixed
-
 - Moved the internal `Convert-ChangelogReleaseNotesToTagMessage` helper functions into `src/private/release` so every `src/public` file now contains exactly one top-level function and CI no longer needs the temporary `Invoke-NovaBuild -OverrideWarning` workaround.
 
+
 ## [0.2.0] - 2026-05-05
-
 ### Added
-
 - Added `Get-KeepAChangelogVersion` and included `KeepAChangelogVersion` in `Move-UnreleasedChangelog` output so CI logs and bug reports show which module version produced the result.
 
-### Changed
 
+### Changed
 - Reworked `README.md` into a maintainer guide that explains the repository layout, local quality flow, CI/CD workflows, ScriptAnalyzer usage, CodeScene usage, release automation, and documentation ownership for the upcoming `1.0.0` release line.
 - Moved the `Initialize-KeepAChangelogFile` internal helper functions into `src/private/initialize` so the initialization workflow follows the same private-helper structure as the rest of the module.
 
-### Fixed
 
+### Fixed
 - Refactored the internal changelog validation helper into smaller private functions so the validation workflow keeps the same behavior while reducing method size and complexity ahead of `1.0.0`.
 - Fixed `Move-UnreleasedChangelog` so re-releasing the same version after moving its notes back into `Unreleased` reuses the real previous release reference instead of generating a self-compare link.
 - Fixed `Move-UnreleasedChangelog` so a new release date cannot be earlier than the latest existing release date in `CHANGELOG.md`, while still allowing first releases and same-day releases.
 
+
 ## [0.1.2] - 2026-05-04
-
 ### Added
-
 - Added a GitHub Pages user manual in `docs/` for people using the `KeepAChangelog` module, with the original keep-a-changelog style, and a changelog panel that shows the current project `CHANGELOG.md`. The site now uses a feature-overview section for the KeepAChangelog module, a dedicated installation and command guide for the public commands, a CI/CD guide in the effort section with example links to the repository workflows, and the version derived from `CHANGELOG.md` to point the index-page version link at the matching PowerShell Gallery package URL.
 
-### Changed
 
+### Changed
 - Changed the `README.md` badges so the changelog-format badge is stable and the version badge is pulled dynamically from PowerShell Gallery instead of hardcoding a released version.
 
+
 ## [0.1.1] - 2026-05-02
-
 ### Added
-
 - Created command `Initialize-KeepAChangelogFile`, allowed without `-PreviousReleaseReference`, and documented `main` and `develop` as valid previous refs.
 - Created command `Move-UnreleasedChangelog`, `-Version` is required release input, and `-Date` is optional with `yyyy-MM-dd` validation.
+
 
 [Unreleased]: https://github.com/stiwicourage/KeepAChangelog/compare/0.2.4...HEAD
 [0.2.4]: https://github.com/stiwicourage/KeepAChangelog/compare/0.2.3...0.2.4
@@ -82,4 +83,3 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 [0.2.0]: https://github.com/stiwicourage/KeepAChangelog/compare/0.1.2...0.2.0
 [0.1.2]: https://github.com/stiwicourage/KeepAChangelog/compare/0.1.1...0.1.2
 [0.1.1]: https://github.com/stiwicourage/KeepAChangelog/compare/103d84a...0.1.1
-

--- a/docs/KeepAChangelog/en-US/Test-KeepAChangelogFile.md
+++ b/docs/KeepAChangelog/en-US/Test-KeepAChangelogFile.md
@@ -28,7 +28,7 @@ PS> Test-KeepAChangelogFile [-Path <string>] [-ThrowOnError] [<CommonParameters>
 `Test-KeepAChangelogFile` reads a changelog and validates:
 
 - the presence of `## [Unreleased]`
-- the `[Unreleased]` compare link when a reference-link footer is present
+- the `[Unreleased]` compare link when a reference-link footer is present, even if blank lines separate the footer links
 - versioned release headings in `## [<version>] - <date>` format
 - duplicate reference-link labels
 

--- a/docs/spec/02-changelog-format-rules.md
+++ b/docs/spec/02-changelog-format-rules.md
@@ -16,6 +16,8 @@ After the first release, the footer must include:
 [Unreleased]: https://github.com/<owner>/<repo>/compare/<previous>...HEAD
 ```
 
+Footer reference links may be written as one compact block or with blank lines between the links. Both layouts are valid as long as the footer only contains reference-link lines.
+
 When the compare link exists, the module extracts:
 
 - The compare-link prefix up to `/compare/`

--- a/project.json
+++ b/project.json
@@ -1,7 +1,7 @@
 {
   "ProjectName": "KeepAChangelog",
   "Description": "PowerShell helpers for creating, validating, and releasing Keep a Changelog files.",
-  "Version": "0.2.4",
+  "Version": "0.2.5-preview",
   "Preamble": [
     "Set-StrictMode -Version Latest"
   ],

--- a/src/private/shared/Split-KeepAChangelogText.ps1
+++ b/src/private/shared/Split-KeepAChangelogText.ps1
@@ -5,7 +5,8 @@ function Split-KeepAChangelogText {
         [string]$Text
     )
 
-    $footerMatch = [regex]::Match($Text, '(?ms)(?<footer>(?:^\[[^\]]+\]:[^\r\n]*(?:\r?\n|$))+)\s*\z')
+    $footerPattern = '(?ms)(?<footer>(?:^\[[^\]]+\]:[^\r\n]*(?:\r?\n(?:[ \t]*\r?\n)*)?)+)\s*\z'
+    $footerMatch = [regex]::Match($Text, $footerPattern)
 
     if ($footerMatch.Success) {
         return [pscustomobject]@{

--- a/tests/KeepAChangelog.Tests.ps1
+++ b/tests/KeepAChangelog.Tests.ps1
@@ -1,34 +1,34 @@
-BeforeAll {
-    & (Join-Path $PSScriptRoot '..' 'scripts' 'build' 'ci' 'Import-BuiltCiModule.ps1') | Out-Null
-    $script:InitializeTestChangelog = {
-        param(
-            [Parameter(Mandatory)]
-            [string]$Path,
-            [string]$PreviousReleaseReference
-        )
+function script:Initialize-TestChangelog {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path,
+        [string]$PreviousReleaseReference
+    )
 
-        $parameters = @{
-            Path          = $Path
-            RepositoryUrl = 'https://github.com/example/repo'
-            Force         = $true
-        }
-
-        if (-not [string]::IsNullOrWhiteSpace($PreviousReleaseReference)) {
-            $parameters.PreviousReleaseReference = $PreviousReleaseReference
-        }
-
-        Initialize-KeepAChangelogFile @parameters | Out-Null
+    $parameters = @{
+        Path          = $Path
+        RepositoryUrl = 'https://github.com/example/repo'
+        Force         = $true
     }
 
-    $script:SetReleaseReadyChangelog = {
-        param(
-            [Parameter(Mandatory)]
-            [string]$Path,
-            [Parameter(Mandatory)]
-            [pscustomobject]$LatestRelease
-        )
+    if (-not [string]::IsNullOrWhiteSpace($PreviousReleaseReference)) {
+        $parameters.PreviousReleaseReference = $PreviousReleaseReference
+    }
 
-        @"
+    Initialize-KeepAChangelogFile @parameters | Out-Null
+}
+
+function script:Set-ReleaseReadyChangelog {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path,
+        [Parameter(Mandatory)]
+        [pscustomobject]$LatestRelease
+    )
+
+    @"
 # Changelog
 
 ## [Unreleased]
@@ -46,7 +46,22 @@ $($LatestRelease.Note)
 [Unreleased]: https://github.com/example/repo/compare/$($LatestRelease.Version)...HEAD
 [$($LatestRelease.Version)]: https://github.com/example/repo/compare/$($LatestRelease.PreviousVersion)...$($LatestRelease.Version)
 "@ | Set-Content -LiteralPath $Path -Encoding utf8
-    }
+}
+
+function script:Get-ReferenceFooterText {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string[]]$LineList,
+        [switch]$SeparateWithBlankLines
+    )
+
+    $separator = if ($SeparateWithBlankLines) { "`n`n" } else { "`n" }
+    return $LineList -join $separator
+}
+
+BeforeAll {
+    & (Join-Path $PSScriptRoot '..' 'scripts' 'build' 'ci' 'Import-BuiltCiModule.ps1') | Out-Null
 }
 
 Describe 'Initialize-KeepAChangelogFile' {
@@ -122,7 +137,7 @@ Describe 'Test-KeepAChangelogFile' {
 
         foreach ($case in $caseList) {
             $path = Join-Path $TestDrive "CHANGELOG-$($case.ExpectedReference ?? 'new').md"
-            & $script:InitializeTestChangelog -Path $path -PreviousReleaseReference $case.PreviousReleaseReference
+            Initialize-TestChangelog -Path $path -PreviousReleaseReference $case.PreviousReleaseReference
             $result = Test-KeepAChangelogFile -Path $path
 
             $result.IsValid | Should -BeTrue
@@ -184,9 +199,27 @@ Describe 'Test-KeepAChangelogFile' {
     }
 
     It 'accepts yanked release headings that follow the Keep a Changelog format' {
-        $path = Join-Path $TestDrive 'CHANGELOG-YANKED.md'
+        $caseList = @(
+            @{
+                Name                     = 'compact-footer'
+                SeparateWithBlankLines   = $false
+            }
+            @{
+                Name                     = 'spaced-footer'
+                SeparateWithBlankLines   = $true
+            }
+        )
 
-        @'
+        foreach ($case in $caseList) {
+            $path = Join-Path $TestDrive "CHANGELOG-YANKED-$($case.Name).md"
+            $footer = Get-ReferenceFooterText `
+                -LineList @(
+                    '[Unreleased]: https://github.com/example/repo/compare/2.2.0...HEAD'
+                    '[2.2.0]: https://github.com/example/repo/releases/tag/2.2.0'
+                ) `
+                -SeparateWithBlankLines:$case.SeparateWithBlankLines
+
+            @"
 # Changelog
 
 ## [Unreleased]
@@ -199,16 +232,16 @@ Describe 'Test-KeepAChangelogFile' {
 
 - Yanked because of a release regression.
 
-[Unreleased]: https://github.com/example/repo/compare/2.2.0...HEAD
-[2.2.0]: https://github.com/example/repo/releases/tag/2.2.0
-'@ | Set-Content -LiteralPath $path -Encoding utf8
+$footer
+"@ | Set-Content -LiteralPath $path -Encoding utf8
 
-        $result = Test-KeepAChangelogFile -Path $path
+            $result = Test-KeepAChangelogFile -Path $path
 
-        $result.IsValid | Should -BeTrue
-        $result.Errors.Count | Should -Be 0
-        @($result.ReleaseVersions) | Should -Be @('2.2.0')
-        $result.PreviousReleaseReference | Should -Be '2.2.0'
+            $result.IsValid | Should -BeTrue
+            $result.Errors.Count | Should -Be 0
+            @($result.ReleaseVersions) | Should -Be @('2.2.0')
+            $result.PreviousReleaseReference | Should -Be '2.2.0'
+        }
     }
 
     It 'throws the validation errors when ThrowOnError is used' {
@@ -232,9 +265,27 @@ Describe 'Test-KeepAChangelogFile' {
 
 Describe 'Move-UnreleasedChangelog' {
     It 'moves unreleased notes into a release section, clears Unreleased, and updates compare links' {
-        $path = Join-Path $TestDrive 'CHANGELOG.md'
+        $caseList = @(
+            @{
+                Name                     = 'compact-footer'
+                SeparateWithBlankLines   = $false
+            }
+            @{
+                Name                     = 'spaced-footer'
+                SeparateWithBlankLines   = $true
+            }
+        )
 
-        @'
+        foreach ($case in $caseList) {
+            $path = Join-Path $TestDrive "CHANGELOG-$($case.Name).md"
+            $footer = Get-ReferenceFooterText `
+                -LineList @(
+                    '[Unreleased]: https://github.com/example/repo/compare/1.5.0...HEAD'
+                    '[1.5.0]: https://github.com/example/repo/compare/1.4.0...1.5.0'
+                ) `
+                -SeparateWithBlankLines:$case.SeparateWithBlankLines
+
+            @"
 # Changelog
 
 ## [Unreleased]
@@ -251,22 +302,24 @@ Describe 'Move-UnreleasedChangelog' {
 
 - Previous release notes.
 
-[Unreleased]: https://github.com/example/repo/compare/1.5.0...HEAD
-[1.5.0]: https://github.com/example/repo/compare/1.4.0...1.5.0
-'@ | Set-Content -LiteralPath $path -Encoding utf8
+$footer
+"@ | Set-Content -LiteralPath $path -Encoding utf8
 
-        $result = Move-UnreleasedChangelog -Path $path -Version '1.6.0' -Date '2026-04-30'
-        $updated = Get-Content -LiteralPath $path -Raw
+            $result = Move-UnreleasedChangelog -Path $path -Version '1.6.0' -Date '2026-04-30'
+            $updated = Get-Content -LiteralPath $path -Raw
 
-        $result.ReleaseNotesBody | Should -Be "### Fixed`n`n- Fixed CLI parsing."
-        $result.ClearedUnreleasedBody | Should -Be "### Added`n`n### Fixed"
-        $result.TagMessageText | Should -Be "Fixed`n`nFixed CLI parsing."
-        $updated | Should -Match '## \[1\.6\.0\] - 2026-04-30'
-        $updated | Should -Match '(?s)## \[1\.6\.0\] - 2026-04-30\s+### Fixed\s+- Fixed CLI parsing\.\s+## \[1\.5\.0\] - 2026-04-10'
-        $updated | Should -Match '(?s)## \[Unreleased\]\s+### Added\s+### Fixed'
-        $updated | Should -Match '\[Unreleased\]: https://github\.com/example/repo/compare/1\.6\.0\.\.\.HEAD'
-        $updated | Should -Match '\[1\.6\.0\]: https://github\.com/example/repo/compare/1\.5\.0\.\.\.1\.6\.0'
-        $result.KeepAChangelogVersion | Should -Be (Get-KeepAChangelogVersion)
+            $result.ReleaseNotesBody | Should -Be "### Fixed`n`n- Fixed CLI parsing."
+            $result.ClearedUnreleasedBody | Should -Be "### Added`n`n### Fixed"
+            $result.PreviousReleaseReference | Should -Be '1.5.0'
+            $result.NewReleaseCompareLink | Should -Be 'https://github.com/example/repo/compare/1.5.0...1.6.0'
+            $result.TagMessageText | Should -Be "Fixed`n`nFixed CLI parsing."
+            $updated | Should -Match '## \[1\.6\.0\] - 2026-04-30'
+            $updated | Should -Match '(?s)## \[1\.6\.0\] - 2026-04-30\s+### Fixed\s+- Fixed CLI parsing\.\s+## \[1\.5\.0\] - 2026-04-10'
+            $updated | Should -Match '(?s)## \[Unreleased\]\s+### Added\s+### Fixed'
+            $updated | Should -Match '\[Unreleased\]: https://github\.com/example/repo/compare/1\.6\.0\.\.\.HEAD'
+            $updated | Should -Match '\[1\.6\.0\]: https://github\.com/example/repo/compare/1\.5\.0\.\.\.1\.6\.0'
+            $result.KeepAChangelogVersion | Should -Be (Get-KeepAChangelogVersion)
+        }
     }
 
     It 'supports simple unreleased notes without subsection headings' {
@@ -444,7 +497,7 @@ Describe 'Move-UnreleasedChangelog' {
         $path = Join-Path $TestDrive 'CHANGELOG.md'
         $currentDate = Get-Date -Format 'yyyy-MM-dd'
 
-        & $script:InitializeTestChangelog -Path $path -PreviousReleaseReference '1.0.0'
+        Initialize-TestChangelog -Path $path -PreviousReleaseReference '1.0.0'
 
         $result = Move-UnreleasedChangelog -Path $path -Version '1.6.0'
 
@@ -470,7 +523,7 @@ Describe 'Move-UnreleasedChangelog' {
 
         foreach ($case in $caseList) {
             $path = Join-Path $TestDrive "CHANGELOG-$($case.Name -replace ' ', '-').md"
-            & $script:SetReleaseReadyChangelog `
+            Set-ReleaseReadyChangelog `
                 -Path $path `
                 -LatestRelease ([pscustomobject]@{
                     Version         = '1.5.0'
@@ -496,7 +549,7 @@ Describe 'Move-UnreleasedChangelog' {
         $currentDate = Get-Date -Format 'yyyy-MM-dd'
         $errorMessage = $null
 
-        & $script:SetReleaseReadyChangelog `
+        Set-ReleaseReadyChangelog `
             -Path $path `
             -LatestRelease ([pscustomobject]@{
                 Version         = '9.9.9'


### PR DESCRIPTION
Summary

 - Fixed changelog footer parsing so Test-KeepAChangelogFile and Move-UnreleasedChangelog accept valid reference-link footers even when blank lines separate the links.
 - Added regression coverage for both compact and blank-line-separated footer layouts, and updated the changelog format spec plus 
Test-KeepAChangelogFile help to document the supported footer layout.
 - The branch also includes the normal develop-side prerelease bookkeeping: project.json moves from 0.2.4 to 0.2.5-preview, and CHANGELOG.md records the fix under Unreleased.
 - This change was needed because valid Keep a Changelog footers were being rejected unless every footer reference-link line was contiguous, which blocked validation and release promotion for spaced footer layouts.
 - No linked issue, discussion, or follow-up reference appears in the origin/main..develop diff.

Affected area

 - [ ]  nova CLI or command routing
 - [X]  Public PowerShell cmdlet behavior
 - [ ]  Scaffolding or project.json handling
 - [ ]  Build, test, analyzer, coverage, or CI helper flow
 - [ ]  Package, raw upload, or package metadata workflow
 - [ ]  Publish, release, semantic-release, or GitHub Actions automation
 - [ ]  Self-update or notification preference behavior
 - [ ]  Contributor documentation (README.md, CONTRIBUTING.md, repository workflow docs)
 - [ ]  End-user docs (docs/*.html)
 - [X]  Command help (docs/NovaModuleTools/en-US/*.md)
 - [ ]  src/resources/example/
 - [X]  Dependency or manifest changes (package.json, workflow dependencies, release tooling)
 - [ ]  Security-sensitive change
 - [ ]  Documentation-only change
 - [ ]  Other

Review guidance

 - Start with src/private/shared/Split-KeepAChangelogText.ps1; the behavioral change is the footer regex that now allows blank lines inside the trailing reference-link footer block.
 - Then review tests/KeepAChangelog.Tests.ps1, which adds compact-vs-spaced footer coverage and refactors test helpers to keep the file maintainable.
 - Primary files changed: src/private/shared/Split-KeepAChangelogText.ps1, tests/KeepAChangelog.Tests.ps1, 
docs/spec/02-changelog-format-rules.md, docs/KeepAChangelog/en-US/Test-KeepAChangelogFile.md, CHANGELOG.md, and project.json.
 - The parser change is intentionally narrow: it broadens accepted footer layout only and does not change release-section parsing. The only release-related branch bookkeeping in this diff is the develop prerelease bump to 0.2.5-preview.

Validation

 - [X]  Invoke-NovaBuild
 - [X]  Test-NovaBuild
 - [X]  ./scripts/build/Invoke-ScriptAnalyzerCI.ps1
 - [ ]  ./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1
 - [ ]  Targeted Nova workflow validated (% nova build, % nova test, % nova merge, % nova deploy,
 % nova publish,
 % nova release, % nova update, % nova notification, or % nova init as relevant)
 - [ ]  Docs/example only; executable validation not needed

Validation notes:

 Validated with:
 pwsh -NoLogo -NoProfile -File ./run.ps1
 
 run.ps1 executes:
 - Invoke-NovaBuild
 - ./scripts/build/Invoke-ScriptAnalyzerCI.ps1
 - Test-NovaBuild
 
Also ran the CodeScene pre-commit safeguard on the current changes; quality gates passed.

Documentation and release follow-up

 - [X]  README.md reviewed and updated if contributor workflow, architecture, CI, release, or automation changed
 - [ ]  CONTRIBUTING.md reviewed and updated if contribution expectations or review guidance changed
 - [X]  CHANGELOG.md reviewed and updated if the change matters to users, maintainers, or contributors
 - [X]  docs/NovaModuleTools/en-US/ help updated if a public command or CLI behavior changed
 - [ ]  docs/*.html updated if end-user workflows or examples changed
 - [ ]  src/resources/example/ reviewed and updated if the real-world project layout, package model, or upload workflow  changed
 - [ ]  No documentation, changelog, or example updates were needed

Maintainability, compatibility, and risk

 - [X]  Code Health / maintainability impact considered
 - [X]  No breaking change
 - [ ]  Breaking change
 - [ ]  Security-sensitive change
 - [X]  CI, workflow, or release-pipeline impact
 - [ ]  Dependency-review impact

Risk, rollout, or rollback notes:

 Low runtime risk: the code change is limited to trailing footer parsing and is covered for both compact and blank-line-separated footer layouts.
 
 No consumer migration is expected.
 
 The branch diff also carries develop-side prerelease bookkeeping (`project.json` -> `0.2.5-preview`). If this is being promoted directly to `main`, confirm that the preview version bump matches the intended release flow or is handled by release automation.

 [!IMPORTANT] Do not use a public pull request to disclose a vulnerability before coordinated handling. Use the private reporting path in  SECURITY.md for new security issues.