### PR TITLE
Support GitLab changelog compare link generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Added
 
 - Added repository-scoped Agentic Copilot workflow scaffolding for maintainers, including specialized agents, reusable prompts, instruction files, skills, a streamlined pull request template, updated contribution guidance, and an internal `RELEASE_NOTE.md` placeholder for future interface-facing release summaries.
+- Added native GitLab footer-link support so changelog initialization, validation, and release updates can generate and preserve GitLab `/-/compare/` and `/-/tags/` URLs, including self-hosted GitLab repositories when `-RepositoryProvider GitLab` is supplied.
 
 ### Changed
 

--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -7,6 +7,8 @@ This file summarizes public cmdlet, CLI, configuration, and migration changes fo
 
 ### Added
 
+- Added native GitLab footer-link support so `Initialize-KeepAChangelogFile` and `Move-UnreleasedChangelog` can use `-RepositoryProvider GitLab` for self-hosted GitLab URLs, while `Test-KeepAChangelogFile` continues to accept GitLab `/-/compare/` links.
+
 ### Changed
 
 ### Deprecated

--- a/docs/KeepAChangelog/en-US/Initialize-KeepAChangelogFile.md
+++ b/docs/KeepAChangelog/en-US/Initialize-KeepAChangelogFile.md
@@ -20,7 +20,7 @@ Initializes a Keep a Changelog template.
 ### __AllParameterSets
 
 ```text
-PS> Initialize-KeepAChangelogFile [-Path <string>] -RepositoryUrl <string> [-PreviousReleaseReference <string>] [-SectionHeading <string[]>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+PS> Initialize-KeepAChangelogFile [-Path <string>] -RepositoryUrl <string> [-RepositoryProvider <string>] [-PreviousReleaseReference <string>] [-SectionHeading <string[]>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -47,10 +47,10 @@ Creates `CHANGELOG.md` with an `[Unreleased]` compare link that starts from `dev
 ### EXAMPLE 2
 
 ```text
-PS> Initialize-KeepAChangelogFile -Path ./CHANGELOG.md -RepositoryUrl https://github.com/couragedk/KeepAChangelog
+PS> Initialize-KeepAChangelogFile -Path ./CHANGELOG.md -RepositoryUrl https://code.example.com/group/project -RepositoryProvider GitLab -PreviousReleaseReference 1.5.2
 ```
 
-Creates a brand-new changelog without footer links so the first release can add them later.
+Creates a changelog for a self-hosted GitLab repository by using the explicit provider hint.
 
 ## PARAMETERS
 
@@ -61,6 +61,15 @@ Target changelog path. Defaults to `CHANGELOG.md`.
 ### -RepositoryUrl
 
 Repository base URL used to build compare links.
+
+GitHub repository URLs generate `/compare/` links. GitLab repository URLs like
+`https://gitlab.com/group/project` generate `/-/compare/` links.
+
+### -RepositoryProvider
+
+Optional provider hint used when `-RepositoryUrl` alone is not enough to infer the compare-link format.
+
+Use `GitLab` for self-hosted GitLab URLs that do not contain `gitlab` in the hostname.
 
 ### -PreviousReleaseReference
 

--- a/docs/KeepAChangelog/en-US/Move-UnreleasedChangelog.md
+++ b/docs/KeepAChangelog/en-US/Move-UnreleasedChangelog.md
@@ -20,7 +20,7 @@ Moves `Unreleased` notes into a versioned release section.
 ### __AllParameterSets
 
 ```text
-PS> Move-UnreleasedChangelog [-Path <string>] -Version <string> [-Date <string>] [-RepositoryUrl <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
+PS> Move-UnreleasedChangelog [-Path <string>] -Version <string> [-Date <string>] [-RepositoryUrl <string>] [-RepositoryProvider <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -56,10 +56,10 @@ Promotes the current unreleased notes into release `1.6.0`.
 ### EXAMPLE 2
 
 ```text
-PS> Move-UnreleasedChangelog -Path ./CHANGELOG.md -Version 1.0.0 -RepositoryUrl https://github.com/couragedk/KeepAChangelog
+PS> Move-UnreleasedChangelog -Path ./CHANGELOG.md -Version 1.0.0 -RepositoryUrl https://code.example.com/group/project -RepositoryProvider GitLab
 ```
 
-Creates the first release and adds the initial footer links for a changelog that did not have a previous release reference.
+Creates the first release and adds GitLab footer links for a self-hosted GitLab repository.
 
 ## PARAMETERS
 
@@ -78,6 +78,14 @@ Optional release date in `yyyy-MM-dd` format.
 ### -RepositoryUrl
 
 Optional repository base URL used to create or maintain footer links when the changelog has no `[Unreleased]` compare link yet.
+
+GitHub repository URLs generate `/compare/` and `/releases/tag/` links. GitLab repository URLs generate `/-/compare/` and `/-/tags/` links.
+
+### -RepositoryProvider
+
+Optional provider hint used when `-RepositoryUrl` must generate new footer links and the host name does not identify the provider clearly.
+
+Use `GitLab` for self-hosted GitLab repository URLs.
 
 ### CommonParameters
 

--- a/docs/KeepAChangelog/en-US/Test-KeepAChangelogFile.md
+++ b/docs/KeepAChangelog/en-US/Test-KeepAChangelogFile.md
@@ -29,6 +29,7 @@ PS> Test-KeepAChangelogFile [-Path <string>] [-ThrowOnError] [<CommonParameters>
 
 - the presence of `## [Unreleased]`
 - the `[Unreleased]` compare link when a reference-link footer is present, even if blank lines separate the footer links
+- GitHub `/compare/` and GitLab `/-/compare/` footer-link formats
 - versioned release headings in `## [<version>] - <date>` format
 - duplicate reference-link labels
 

--- a/src/private/initialize/Get-KeepAChangelogFooterLine.ps1
+++ b/src/private/initialize/Get-KeepAChangelogFooterLine.ps1
@@ -3,6 +3,7 @@ function Get-KeepAChangelogFooterLine {
     param(
         [Parameter(Mandatory)]
         [string]$RepositoryUrl,
+        [string]$RepositoryProvider,
         [string]$PreviousReleaseReference
     )
 
@@ -10,5 +11,8 @@ function Get-KeepAChangelogFooterLine {
         return $null
     }
 
-    return "[Unreleased]: $RepositoryUrl/compare/$PreviousReleaseReference...HEAD"
+    $repositoryLinkData = Get-KeepAChangelogRepositoryLinkData `
+        -RepositoryUrl $RepositoryUrl `
+        -RepositoryProvider $RepositoryProvider
+    return "[Unreleased]: $($repositoryLinkData.UnreleasedCompareLinkPrefix)$PreviousReleaseReference...HEAD"
 }

--- a/src/private/initialize/Get-KeepAChangelogTemplateText.ps1
+++ b/src/private/initialize/Get-KeepAChangelogTemplateText.ps1
@@ -3,12 +3,16 @@ function Get-KeepAChangelogTemplateText {
     param(
         [Parameter(Mandatory)]
         [string]$RepositoryUrl,
+        [string]$RepositoryProvider,
         [string]$PreviousReleaseReference,
         [Parameter(Mandatory)]
         [string[]]$SectionHeading
     )
 
-    $footerLine = Get-KeepAChangelogFooterLine -RepositoryUrl $RepositoryUrl -PreviousReleaseReference $PreviousReleaseReference
+    $footerLine = Get-KeepAChangelogFooterLine `
+        -RepositoryUrl $RepositoryUrl `
+        -RepositoryProvider $RepositoryProvider `
+        -PreviousReleaseReference $PreviousReleaseReference
     $lineList = @(
         '# Changelog'
         ''

--- a/src/private/release/Get-KeepAChangelogPreviousReleaseReference.ps1
+++ b/src/private/release/Get-KeepAChangelogPreviousReleaseReference.ps1
@@ -5,12 +5,12 @@ function Get-ChangelogReleaseTargetReference {
         [string]$Link
     )
 
-    $compareMatch = [regex]::Match($Link, '/compare/.+\.\.\.(?<target>.+)$')
+    $compareMatch = [regex]::Match($Link, '/(?:compare|-/compare)/.+\.\.\.(?<target>.+)$')
     if ($compareMatch.Success) {
         return $compareMatch.Groups['target'].Value
     }
 
-    $tagMatch = [regex]::Match($Link, '/releases/tag/(?<target>.+)$')
+    $tagMatch = [regex]::Match($Link, '/(?:releases/tag|-/tags)/(?<target>.+)$')
     if ($tagMatch.Success) {
         return $tagMatch.Groups['target'].Value
     }

--- a/src/private/release/Get-UpdatedChangelogReferenceFooter.ps1
+++ b/src/private/release/Get-UpdatedChangelogReferenceFooter.ps1
@@ -26,26 +26,11 @@ function Get-ChangelogReferenceLinkData {
     }
 }
 
-function Get-NormalizedChangelogRepositoryUrl {
-    [CmdletBinding()]
-    param(
-        [string]$RepositoryUrl,
-        [Parameter(Mandatory)]
-        [string]$UnreleasedCompareLinkPrefix
-    )
-
-    if ([string]::IsNullOrWhiteSpace($RepositoryUrl)) {
-        return ($UnreleasedCompareLinkPrefix -replace '/compare/$', '')
-    }
-
-    return $RepositoryUrl.TrimEnd('/')
-}
-
 function Get-ChangelogReleaseLink {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
-        [string]$RepositoryUrl,
+        [string]$ReleaseTagPrefix,
         [Parameter(Mandatory)]
         [string]$UnreleasedCompareLinkPrefix,
         [AllowEmptyString()]
@@ -55,7 +40,7 @@ function Get-ChangelogReleaseLink {
     )
 
     if ([string]::IsNullOrWhiteSpace($PreviousReleaseReference)) {
-        return "$RepositoryUrl/releases/tag/$ReleaseTag"
+        return "$ReleaseTagPrefix$ReleaseTag"
     }
 
     return "$UnreleasedCompareLinkPrefix$PreviousReleaseReference...$ReleaseTag"
@@ -115,12 +100,9 @@ function Get-UpdatedChangelogReferenceFooter {
         $orderedLabelList.Add('Unreleased')
     }
 
-    $normalizedRepositoryUrl = Get-NormalizedChangelogRepositoryUrl `
-        -RepositoryUrl $Context.RepositoryUrl `
-        -UnreleasedCompareLinkPrefix $Context.UnreleasedCompareLinkPrefix
     $updatedUnreleasedLink = "$($Context.UnreleasedCompareLinkPrefix)$($Release.Tag)...HEAD"
     $newReleaseLink = Get-ChangelogReleaseLink `
-        -RepositoryUrl $normalizedRepositoryUrl `
+        -ReleaseTagPrefix $Context.ReleaseTagPrefix `
         -UnreleasedCompareLinkPrefix $Context.UnreleasedCompareLinkPrefix `
         -PreviousReleaseReference $Context.PreviousReleaseReference `
         -ReleaseTag $Release.Tag

--- a/src/private/release/Resolve-KeepAChangelogReleaseData.ps1
+++ b/src/private/release/Resolve-KeepAChangelogReleaseData.ps1
@@ -1,3 +1,19 @@
+function Get-KeepAChangelogRepositoryState {
+    [CmdletBinding()]
+    param(
+        [string]$RepositoryUrl,
+        [string]$RepositoryProvider,
+        [AllowEmptyString()]
+        [string]$Footer
+    )
+
+    return [pscustomobject]@{
+        Footer             = $Footer
+        RepositoryProvider = $RepositoryProvider
+        RepositoryUrl      = $RepositoryUrl
+    }
+}
+
 function Assert-KeepAChangelogValidation {
     [CmdletBinding()]
     param(
@@ -13,20 +29,19 @@ function Assert-KeepAChangelogValidation {
 function Get-KeepAChangelogRepositoryContext {
     [CmdletBinding()]
     param(
-        [string]$RepositoryUrl,
-        [AllowEmptyString()]
-        [string]$Footer,
+        [Parameter(Mandatory)]
+        [pscustomobject]$RepositoryState,
         [Parameter(Mandatory)]
         [pscustomobject]$Release,
         [Parameter(Mandatory)]
         [pscustomobject]$Validation
     )
 
-    $normalizedRepositoryUrl = if ([string]::IsNullOrWhiteSpace($RepositoryUrl)) {
+    $normalizedRepositoryUrl = if ([string]::IsNullOrWhiteSpace($RepositoryState.RepositoryUrl)) {
         $null
     }
     else {
-        $RepositoryUrl.TrimEnd('/')
+        $RepositoryState.RepositoryUrl.TrimEnd('/')
     }
 
     $unreleasedCompareLinkPrefix = $Validation.UnreleasedCompareLinkPrefix
@@ -37,27 +52,27 @@ function Get-KeepAChangelogRepositoryContext {
         return [pscustomobject]@{
             RepositoryUrl               = $null
             UnreleasedCompareLinkPrefix = $null
+            ReleaseTagPrefix            = $null
             PreviousReleaseReference    = $null
             ShouldWriteReferenceFooter  = $false
         }
     }
 
-    if ([string]::IsNullOrWhiteSpace($unreleasedCompareLinkPrefix)) {
-        $unreleasedCompareLinkPrefix = "$normalizedRepositoryUrl/compare/"
-    }
-
-    if ([string]::IsNullOrWhiteSpace($normalizedRepositoryUrl)) {
-        $normalizedRepositoryUrl = $unreleasedCompareLinkPrefix -replace '/compare/$', ''
-    }
+    $repositoryLinkData = Get-KeepAChangelogRepositoryLinkData `
+        -RepositoryUrl $normalizedRepositoryUrl `
+        -RepositoryProvider $RepositoryState.RepositoryProvider `
+        -UnreleasedCompareLinkPrefix $unreleasedCompareLinkPrefix
 
     $previousReleaseReference = Get-KeepAChangelogPreviousReleaseReference `
-        -Footer $Footer `
+        -Footer $RepositoryState.Footer `
         -Validation $Validation `
         -Release $Release
 
     return [pscustomobject]@{
-        RepositoryUrl               = $normalizedRepositoryUrl
-        UnreleasedCompareLinkPrefix = $unreleasedCompareLinkPrefix
+        RepositoryProvider          = $repositoryLinkData.RepositoryProvider
+        RepositoryUrl               = $repositoryLinkData.RepositoryUrl
+        UnreleasedCompareLinkPrefix = $repositoryLinkData.UnreleasedCompareLinkPrefix
+        ReleaseTagPrefix            = $repositoryLinkData.ReleaseTagPrefix
         PreviousReleaseReference    = $previousReleaseReference
         ShouldWriteReferenceFooter  = $true
     }
@@ -116,7 +131,8 @@ function Resolve-KeepAChangelogReleaseData {
         [Parameter(Mandatory)]
         [hashtable]$Release,
 
-        [string]$RepositoryUrl
+        [string]$RepositoryUrl,
+        [string]$RepositoryProvider
     )
 
     $normalizedRelease = Assert-KeepAChangelogRelease -Release $Release
@@ -125,9 +141,12 @@ function Resolve-KeepAChangelogReleaseData {
     $parts = Split-KeepAChangelogText -Text $Text
     Assert-KeepAChangelogReleaseDateOrder -Body $parts.Body -Release $normalizedRelease
     $unreleasedSectionMatch = Get-UnreleasedSectionMatch -Text $parts.Body
-    $repositoryContext = Get-KeepAChangelogRepositoryContext `
+    $repositoryState = Get-KeepAChangelogRepositoryState `
         -RepositoryUrl $RepositoryUrl `
-        -Footer $parts.Footer `
+        -RepositoryProvider $RepositoryProvider `
+        -Footer $parts.Footer
+    $repositoryContext = Get-KeepAChangelogRepositoryContext `
+        -RepositoryState $repositoryState `
         -Release $normalizedRelease `
         -Validation $validation
     $unreleasedBody = $unreleasedSectionMatch.Groups['body'].Value.Trim()

--- a/src/private/shared/Get-KeepAChangelogRepositoryLinkData.ps1
+++ b/src/private/shared/Get-KeepAChangelogRepositoryLinkData.ps1
@@ -1,0 +1,127 @@
+function Test-KeepAChangelogGitLabRepositoryUrl {
+    [CmdletBinding()]
+    param(
+        [string]$RepositoryUrl
+    )
+
+    if ([string]::IsNullOrWhiteSpace($RepositoryUrl)) {
+        return $false
+    }
+
+    return $RepositoryUrl -match '^https?://[^/]*gitlab[^/]*/'
+}
+
+function Get-KeepAChangelogRepositoryProvider {
+    [CmdletBinding()]
+    param(
+        [string]$RepositoryProvider,
+        [string]$RepositoryUrl,
+        [string]$UnreleasedCompareLinkPrefix
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($UnreleasedCompareLinkPrefix)) {
+        if ($UnreleasedCompareLinkPrefix.TrimEnd('/') -like '*-/compare') {
+            return 'GitLab'
+        }
+
+        return 'GitHub'
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($RepositoryProvider)) {
+        return $RepositoryProvider
+    }
+
+    if (Test-KeepAChangelogGitLabRepositoryUrl -RepositoryUrl $RepositoryUrl) {
+        return 'GitLab'
+    }
+
+    return 'GitHub'
+}
+
+function Get-KeepAChangelogComparePath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$RepositoryProvider
+    )
+
+    if ($RepositoryProvider -eq 'GitLab') {
+        return '/-/compare/'
+    }
+
+    return '/compare/'
+}
+
+function Get-KeepAChangelogReleaseTagPath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$RepositoryProvider
+    )
+
+    if ($RepositoryProvider -eq 'GitLab') {
+        return '/-/tags/'
+    }
+
+    return '/releases/tag/'
+}
+
+function Resolve-KeepAChangelogRepositoryUrlFromComparePrefix {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$UnreleasedCompareLinkPrefix,
+        [Parameter(Mandatory)]
+        [string]$ComparePath
+    )
+
+    $normalizedPrefix = $UnreleasedCompareLinkPrefix.TrimEnd('/')
+    $compareSuffix = $ComparePath.TrimEnd('/')
+
+    return $normalizedPrefix.Substring(0, $normalizedPrefix.Length - $compareSuffix.Length)
+}
+
+function Get-KeepAChangelogRepositoryLinkData {
+    [CmdletBinding()]
+    param(
+        [string]$RepositoryUrl,
+        [string]$RepositoryProvider,
+        [string]$UnreleasedCompareLinkPrefix
+    )
+
+    if ([string]::IsNullOrWhiteSpace($RepositoryUrl) -and [string]::IsNullOrWhiteSpace($UnreleasedCompareLinkPrefix)) {
+        return [pscustomobject]@{
+            RepositoryProvider          = $null
+            RepositoryUrl               = $null
+            UnreleasedCompareLinkPrefix = $null
+            ReleaseTagPrefix            = $null
+        }
+    }
+
+    $normalizedRepositoryUrl = if ([string]::IsNullOrWhiteSpace($RepositoryUrl)) {
+        $null
+    }
+    else {
+        $RepositoryUrl.TrimEnd('/')
+    }
+
+    $resolvedRepositoryProvider = Get-KeepAChangelogRepositoryProvider `
+        -RepositoryProvider $RepositoryProvider `
+        -RepositoryUrl $normalizedRepositoryUrl `
+        -UnreleasedCompareLinkPrefix $UnreleasedCompareLinkPrefix
+    $comparePath = Get-KeepAChangelogComparePath `
+        -RepositoryProvider $resolvedRepositoryProvider
+
+    if ([string]::IsNullOrWhiteSpace($normalizedRepositoryUrl)) {
+        $normalizedRepositoryUrl = Resolve-KeepAChangelogRepositoryUrlFromComparePrefix `
+            -UnreleasedCompareLinkPrefix $UnreleasedCompareLinkPrefix `
+            -ComparePath $comparePath
+    }
+
+    return [pscustomobject]@{
+        RepositoryProvider          = $resolvedRepositoryProvider
+        RepositoryUrl               = $normalizedRepositoryUrl
+        UnreleasedCompareLinkPrefix = "$normalizedRepositoryUrl$comparePath"
+        ReleaseTagPrefix            = "$normalizedRepositoryUrl$(Get-KeepAChangelogReleaseTagPath -RepositoryProvider $resolvedRepositoryProvider)"
+    }
+}

--- a/src/private/shared/Get-KeepAChangelogRepositoryProviderParameterDictionary.ps1
+++ b/src/private/shared/Get-KeepAChangelogRepositoryProviderParameterDictionary.ps1
@@ -1,0 +1,18 @@
+function Get-KeepAChangelogRepositoryProviderParameterDictionary {
+    [CmdletBinding()]
+    param()
+
+    $attribute = [System.Management.Automation.ParameterAttribute]::new()
+    $attributeCollection = [System.Collections.ObjectModel.Collection[System.Attribute]]::new()
+    $attributeCollection.Add($attribute)
+    $attributeCollection.Add([System.Management.Automation.ValidateSetAttribute]::new('GitHub', 'GitLab'))
+
+    $parameter = [System.Management.Automation.RuntimeDefinedParameter]::new(
+        'RepositoryProvider',
+        [string],
+        $attributeCollection
+    )
+    $parameterDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+    $parameterDictionary.Add('RepositoryProvider', $parameter)
+    return $parameterDictionary
+}

--- a/src/public/Initialize-KeepAChangelogFile.ps1
+++ b/src/public/Initialize-KeepAChangelogFile.ps1
@@ -14,22 +14,30 @@ function Initialize-KeepAChangelogFile {
         [switch]$Force
     )
 
-    Assert-KeepAChangelogInitialization -Path $Path -RepositoryUrl $RepositoryUrl -Force $Force.IsPresent
-    $normalizedRepositoryUrl = $RepositoryUrl.TrimEnd('/')
-    $template = Get-KeepAChangelogTemplateText `
-        -RepositoryUrl $normalizedRepositoryUrl `
-        -PreviousReleaseReference $PreviousReleaseReference `
-        -SectionHeading $SectionHeading
-
-    if (-not $PSCmdlet.ShouldProcess($Path, 'Initialize Keep a Changelog template')) {
-        return
+    dynamicparam {
+        return Get-KeepAChangelogRepositoryProviderParameterDictionary
     }
 
-    Set-Content -LiteralPath $Path -Value $template -Encoding utf8
+    begin {
+        Assert-KeepAChangelogInitialization -Path $Path -RepositoryUrl $RepositoryUrl -Force $Force.IsPresent
+        $normalizedRepositoryUrl = $RepositoryUrl.TrimEnd('/')
+        $repositoryProvider = $PSBoundParameters['RepositoryProvider']
+        $template = Get-KeepAChangelogTemplateText `
+            -RepositoryUrl $normalizedRepositoryUrl `
+            -RepositoryProvider $repositoryProvider `
+            -PreviousReleaseReference $PreviousReleaseReference `
+            -SectionHeading $SectionHeading
 
-    return [pscustomobject]@{
-        Path                     = $Path
-        RepositoryUrl            = $normalizedRepositoryUrl
-        PreviousReleaseReference = if ([string]::IsNullOrWhiteSpace($PreviousReleaseReference)) { $null } else { $PreviousReleaseReference }
+        if (-not $PSCmdlet.ShouldProcess($Path, 'Initialize Keep a Changelog template')) {
+            return
+        }
+
+        Set-Content -LiteralPath $Path -Value $template -Encoding utf8
+
+        return [pscustomobject]@{
+            Path                     = $Path
+            RepositoryUrl            = $normalizedRepositoryUrl
+            PreviousReleaseReference = if ([string]::IsNullOrWhiteSpace($PreviousReleaseReference)) { $null } else { $PreviousReleaseReference }
+        }
     }
 }

--- a/src/public/Move-UnreleasedChangelog.ps1
+++ b/src/public/Move-UnreleasedChangelog.ps1
@@ -12,30 +12,41 @@ function Move-UnreleasedChangelog {
         [string]$RepositoryUrl
     )
 
-    if ([string]::IsNullOrWhiteSpace($Version)) {
-        throw 'Version is required.'
+    dynamicparam {
+        return Get-KeepAChangelogRepositoryProviderParameterDictionary
     }
 
-    if (-not (Test-Path -LiteralPath $Path)) {
-        throw "Could not find CHANGELOG file at '$Path'."
-    }
+    begin {
+        if ([string]::IsNullOrWhiteSpace($Version)) {
+            throw 'Version is required.'
+        }
 
-    $releaseDate = Resolve-KeepAChangelogReleaseDate -Date $Date
-    $release = @{
-        Version = $Version
-        Date    = $releaseDate
-        Tag     = $Version
-    }
+        if (-not (Test-Path -LiteralPath $Path)) {
+            throw "Could not find CHANGELOG file at '$Path'."
+        }
 
-    $text = Get-Content -LiteralPath $Path -Raw
-    $result = Resolve-KeepAChangelogReleaseData -Text $text -Release $release -RepositoryUrl $RepositoryUrl
-    $result | Add-Member -NotePropertyName KeepAChangelogVersion -NotePropertyValue (Get-KeepAChangelogModuleVersion) -Force
-    $targetVersion = $result.Release.Version
+        $releaseDate = Resolve-KeepAChangelogReleaseDate -Date $Date
+        $release = @{
+            Version = $Version
+            Date    = $releaseDate
+            Tag     = $Version
+        }
 
-    if (-not $PSCmdlet.ShouldProcess($Path, "Promote [Unreleased] to [$targetVersion]")) {
+        $repositoryProvider = $PSBoundParameters['RepositoryProvider']
+        $text = Get-Content -LiteralPath $Path -Raw
+        $result = Resolve-KeepAChangelogReleaseData `
+            -Text $text `
+            -Release $release `
+            -RepositoryUrl $RepositoryUrl `
+            -RepositoryProvider $repositoryProvider
+        $result | Add-Member -NotePropertyName KeepAChangelogVersion -NotePropertyValue (Get-KeepAChangelogModuleVersion) -Force
+        $targetVersion = $result.Release.Version
+
+        if (-not $PSCmdlet.ShouldProcess($Path, "Promote [Unreleased] to [$targetVersion]")) {
+            return $result
+        }
+
+        Set-Content -LiteralPath $Path -Value $result.UpdatedText -Encoding utf8
         return $result
     }
-
-    Set-Content -LiteralPath $Path -Value $result.UpdatedText -Encoding utf8
-    return $result
 }

--- a/tests/private/initialize/Get-KeepAChangelogFooterLine.Tests.ps1
+++ b/tests/private/initialize/Get-KeepAChangelogFooterLine.Tests.ps1
@@ -1,0 +1,38 @@
+BeforeAll {
+    . (Join-Path $PSScriptRoot '..' '..' 'TestHelpers' 'Get-KeepAChangelogProjectRoot.ps1')
+    . (Join-Path $PSScriptRoot '..' '..' 'TestHelpers' 'Import-KeepAChangelogSourceFile.ps1')
+
+    $projectRoot = Get-KeepAChangelogProjectRoot -StartPath $PSScriptRoot
+    Import-KeepAChangelogSourceFile -ProjectRoot $projectRoot -RelativePath @(
+        'src/private/shared/Get-KeepAChangelogRepositoryLinkData.ps1'
+        'src/private/initialize/Get-KeepAChangelogFooterLine.ps1'
+    ) | ForEach-Object { . $_.FullName }
+}
+
+Describe 'Get-KeepAChangelogFooterLine' {
+    It 'uses the explicit provider when building the Unreleased footer link' -ForEach @(
+        @{
+            RepositoryUrl = 'https://github.com/example/repo'
+            RepositoryProvider = 'GitHub'
+            PreviousReleaseReference = '1.0.0'
+            ExpectedFooterLine = '[Unreleased]: https://github.com/example/repo/compare/1.0.0...HEAD'
+        }
+        @{
+            RepositoryUrl = 'https://code.example.com/group/project'
+            RepositoryProvider = 'GitLab'
+            PreviousReleaseReference = '1.0.0'
+            ExpectedFooterLine = '[Unreleased]: https://code.example.com/group/project/-/compare/1.0.0...HEAD'
+        }
+    ) {
+        $result = Get-KeepAChangelogFooterLine `
+            -RepositoryUrl $RepositoryUrl `
+            -RepositoryProvider $RepositoryProvider `
+            -PreviousReleaseReference $PreviousReleaseReference
+
+        $result | Should -Be $ExpectedFooterLine
+    }
+
+    It 'returns null when PreviousReleaseReference is omitted' {
+        Get-KeepAChangelogFooterLine -RepositoryUrl 'https://github.com/example/repo' | Should -BeNullOrEmpty
+    }
+}

--- a/tests/private/initialize/Get-KeepAChangelogTemplateText.Tests.ps1
+++ b/tests/private/initialize/Get-KeepAChangelogTemplateText.Tests.ps1
@@ -1,0 +1,22 @@
+BeforeAll {
+    . (Join-Path $PSScriptRoot '..' '..' 'TestHelpers' 'Get-KeepAChangelogProjectRoot.ps1')
+    . (Join-Path $PSScriptRoot '..' '..' 'TestHelpers' 'Import-KeepAChangelogSourceFile.ps1')
+
+    $projectRoot = Get-KeepAChangelogProjectRoot -StartPath $PSScriptRoot
+    Import-KeepAChangelogSourceFile -ProjectRoot $projectRoot -RelativePath @(
+        'src/private/shared/Get-KeepAChangelogRepositoryLinkData.ps1'
+        'src/private/initialize/*.ps1'
+    ) | ForEach-Object { . $_.FullName }
+}
+
+Describe 'Get-KeepAChangelogTemplateText' {
+    It 'includes a GitLab compare footer when the explicit provider is GitLab' {
+        $result = Get-KeepAChangelogTemplateText `
+            -RepositoryUrl 'https://code.example.com/group/project' `
+            -RepositoryProvider 'GitLab' `
+            -PreviousReleaseReference '1.0.0' `
+            -SectionHeading @('Added', 'Fixed')
+
+        $result | Should -Match '\[Unreleased\]: https://code\.example\.com/group/project/-/compare/1\.0\.0\.\.\.HEAD'
+    }
+}

--- a/tests/private/release/Get-KeepAChangelogPreviousReleaseReference.Tests.ps1
+++ b/tests/private/release/Get-KeepAChangelogPreviousReleaseReference.Tests.ps1
@@ -10,8 +10,11 @@ BeforeAll {
 }
 
 Describe 'Get-KeepAChangelogPreviousReleaseReference' {
-    It 'extracts the target from release tag links' {
-        $result = Get-ChangelogReleaseTargetReference -Link 'https://github.com/example/repo/releases/tag/1.0.0'
+    It 'extracts the target from release tag links' -ForEach @(
+        'https://github.com/example/repo/releases/tag/1.0.0'
+        'https://gitlab.com/example/repo/-/tags/1.0.0'
+    ) {
+        $result = Get-ChangelogReleaseTargetReference -Link $_
 
         $result | Should -Be '1.0.0'
     }

--- a/tests/private/release/Get-UpdatedChangelogReferenceFooter.Tests.ps1
+++ b/tests/private/release/Get-UpdatedChangelogReferenceFooter.Tests.ps1
@@ -9,7 +9,16 @@ BeforeAll {
 }
 
 Describe 'Get-UpdatedChangelogReferenceFooter' {
-    It 'derives the release link from the compare prefix when RepositoryUrl is omitted' {
+    It 'derives the release link from the compare prefix when RepositoryUrl is omitted' -ForEach @(
+        @{
+            Prefix         = 'https://github.com/example/repo/compare/'
+            ReleaseTagLink = 'https://github.com/example/repo/releases/tag/1.0.0'
+        }
+        @{
+            Prefix         = 'https://gitlab.com/example/repo/-/compare/'
+            ReleaseTagLink = 'https://gitlab.com/example/repo/-/tags/1.0.0'
+        }
+    ) {
         $result = Get-UpdatedChangelogReferenceFooter `
             -Footer '' `
             -Release ([pscustomobject]@{
@@ -18,11 +27,12 @@ Describe 'Get-UpdatedChangelogReferenceFooter' {
             }) `
             -Context ([pscustomobject]@{
                 RepositoryUrl               = $null
-                UnreleasedCompareLinkPrefix = 'https://github.com/example/repo/compare/'
+                ReleaseTagPrefix            = $ReleaseTagLink -replace '1.0.0$', ''
+                UnreleasedCompareLinkPrefix = $Prefix
                 PreviousReleaseReference    = ''
             })
 
-        $result.Footer | Should -Be "[Unreleased]: https://github.com/example/repo/compare/1.0.0...HEAD`n[1.0.0]: https://github.com/example/repo/releases/tag/1.0.0"
+        $result.Footer | Should -Be "[Unreleased]: $($Prefix)1.0.0...HEAD`n[1.0.0]: $ReleaseTagLink"
     }
 
     It 'returns an empty footer update when links should not be written' {

--- a/tests/private/release/Resolve-KeepAChangelogReleaseData.Tests.ps1
+++ b/tests/private/release/Resolve-KeepAChangelogReleaseData.Tests.ps1
@@ -28,4 +28,44 @@ Describe 'Resolve-KeepAChangelogReleaseData' {
 
         $errorMessage | Should -Be 'CHANGELOG.md is not valid. Could not find ## [Unreleased] section in CHANGELOG.md.'
     }
+
+    It 'builds GitLab compare and tag links from a GitLab repository URL' {
+        $result = Resolve-KeepAChangelogReleaseData -Text @'
+# Changelog
+
+## [Unreleased]
+
+### Added
+
+- Initial release notes.
+'@ -Release @{
+            Version = '1.0.0'
+            Date    = '2026-05-03'
+            Tag     = '1.0.0'
+        } -RepositoryUrl 'https://gitlab.com/example/repo'
+
+        $result.UnreleasedCompareLinkPrefix | Should -Be 'https://gitlab.com/example/repo/-/compare/'
+        $result.UpdatedUnreleasedLink | Should -Be 'https://gitlab.com/example/repo/-/compare/1.0.0...HEAD'
+        $result.NewReleaseLink | Should -Be 'https://gitlab.com/example/repo/-/tags/1.0.0'
+    }
+
+    It 'uses the explicit provider for self-hosted GitLab repository URLs' {
+        $result = Resolve-KeepAChangelogReleaseData -Text @'
+# Changelog
+
+## [Unreleased]
+
+### Added
+
+- Initial release notes.
+'@ -Release @{
+            Version = '1.0.0'
+            Date    = '2026-05-03'
+            Tag     = '1.0.0'
+        } -RepositoryUrl 'https://code.example.com/group/project' -RepositoryProvider 'GitLab'
+
+        $result.UnreleasedCompareLinkPrefix | Should -Be 'https://code.example.com/group/project/-/compare/'
+        $result.UpdatedUnreleasedLink | Should -Be 'https://code.example.com/group/project/-/compare/1.0.0...HEAD'
+        $result.NewReleaseLink | Should -Be 'https://code.example.com/group/project/-/tags/1.0.0'
+    }
 }

--- a/tests/private/shared/Get-KeepAChangelogRepositoryLinkData.Tests.ps1
+++ b/tests/private/shared/Get-KeepAChangelogRepositoryLinkData.Tests.ps1
@@ -1,0 +1,89 @@
+BeforeAll {
+    . (Join-Path $PSScriptRoot '..' '..' 'TestHelpers' 'Get-KeepAChangelogProjectRoot.ps1')
+    . (Join-Path $PSScriptRoot '..' '..' 'TestHelpers' 'Import-KeepAChangelogSourceFile.ps1')
+
+    $projectRoot = Get-KeepAChangelogProjectRoot -StartPath $PSScriptRoot
+    Import-KeepAChangelogSourceFile -ProjectRoot $projectRoot -RelativePath @(
+        'src/private/shared/Get-KeepAChangelogRepositoryLinkData.ps1'
+    ) | ForEach-Object { . $_.FullName }
+}
+
+Describe 'Get-KeepAChangelogRepositoryLinkData' {
+    It 'returns null link data when neither a repository URL nor compare prefix is available' {
+        $result = Get-KeepAChangelogRepositoryLinkData
+
+        $result.RepositoryProvider | Should -BeNullOrEmpty
+        $result.RepositoryUrl | Should -BeNullOrEmpty
+        $result.UnreleasedCompareLinkPrefix | Should -BeNullOrEmpty
+        $result.ReleaseTagPrefix | Should -BeNullOrEmpty
+    }
+
+    It 'builds provider-specific compare and tag prefixes from a repository URL' -ForEach @(
+        @{
+            ExpectedProvider           = 'GitHub'
+            RepositoryUrl               = 'https://github.com/example/repo'
+            UnreleasedCompareLinkPrefix = 'https://github.com/example/repo/compare/'
+            ReleaseTagPrefix            = 'https://github.com/example/repo/releases/tag/'
+        }
+        @{
+            ExpectedProvider           = 'GitLab'
+            RepositoryUrl               = 'https://gitlab.com/example/repo'
+            UnreleasedCompareLinkPrefix = 'https://gitlab.com/example/repo/-/compare/'
+            ReleaseTagPrefix            = 'https://gitlab.com/example/repo/-/tags/'
+        }
+    ) {
+        $result = Get-KeepAChangelogRepositoryLinkData -RepositoryUrl $RepositoryUrl
+
+        $result.RepositoryProvider | Should -Be $ExpectedProvider
+        $result.RepositoryUrl | Should -Be $RepositoryUrl
+        $result.UnreleasedCompareLinkPrefix | Should -Be $UnreleasedCompareLinkPrefix
+        $result.ReleaseTagPrefix | Should -Be $ReleaseTagPrefix
+    }
+
+    It 'derives the repository URL and tag prefix from an existing compare prefix' -ForEach @(
+        @{
+            ExpectedProvider           = 'GitHub'
+            RepositoryUrl               = 'https://github.com/example/repo'
+            UnreleasedCompareLinkPrefix = 'https://github.com/example/repo/compare/'
+            ReleaseTagPrefix            = 'https://github.com/example/repo/releases/tag/'
+        }
+        @{
+            ExpectedProvider           = 'GitLab'
+            RepositoryUrl               = 'https://gitlab.com/example/repo'
+            UnreleasedCompareLinkPrefix = 'https://gitlab.com/example/repo/-/compare/'
+            ReleaseTagPrefix            = 'https://gitlab.com/example/repo/-/tags/'
+        }
+    ) {
+        $result = Get-KeepAChangelogRepositoryLinkData -UnreleasedCompareLinkPrefix $UnreleasedCompareLinkPrefix
+
+        $result.RepositoryProvider | Should -Be $ExpectedProvider
+        $result.RepositoryUrl | Should -Be $RepositoryUrl
+        $result.UnreleasedCompareLinkPrefix | Should -Be $UnreleasedCompareLinkPrefix
+        $result.ReleaseTagPrefix | Should -Be $ReleaseTagPrefix
+    }
+
+    It 'treats blank repository URLs as non-GitLab URLs' {
+        Test-KeepAChangelogGitLabRepositoryUrl -RepositoryUrl '   ' | Should -BeFalse
+    }
+
+    It 'uses the explicit provider for self-hosted GitLab repository URLs' {
+        $result = Get-KeepAChangelogRepositoryLinkData `
+            -RepositoryUrl 'https://code.example.com/group/project' `
+            -RepositoryProvider 'GitLab'
+
+        $result.RepositoryProvider | Should -Be 'GitLab'
+        $result.UnreleasedCompareLinkPrefix | Should -Be 'https://code.example.com/group/project/-/compare/'
+        $result.ReleaseTagPrefix | Should -Be 'https://code.example.com/group/project/-/tags/'
+    }
+
+    It 'preserves the existing compare-link provider over an explicit parameter' {
+        $result = Get-KeepAChangelogRepositoryLinkData `
+            -RepositoryUrl 'https://code.example.com/group/project' `
+            -RepositoryProvider 'GitHub' `
+            -UnreleasedCompareLinkPrefix 'https://code.example.com/group/project/-/compare/'
+
+        $result.RepositoryProvider | Should -Be 'GitLab'
+        $result.UnreleasedCompareLinkPrefix | Should -Be 'https://code.example.com/group/project/-/compare/'
+        $result.ReleaseTagPrefix | Should -Be 'https://code.example.com/group/project/-/tags/'
+    }
+}

--- a/tests/private/shared/Get-KeepAChangelogRepositoryProviderParameterDictionary.Tests.ps1
+++ b/tests/private/shared/Get-KeepAChangelogRepositoryProviderParameterDictionary.Tests.ps1
@@ -1,0 +1,21 @@
+BeforeAll {
+    . (Join-Path $PSScriptRoot '..' '..' 'TestHelpers' 'Get-KeepAChangelogProjectRoot.ps1')
+    . (Join-Path $PSScriptRoot '..' '..' 'TestHelpers' 'Import-KeepAChangelogSourceFile.ps1')
+
+    $projectRoot = Get-KeepAChangelogProjectRoot -StartPath $PSScriptRoot
+    Import-KeepAChangelogSourceFile -ProjectRoot $projectRoot -RelativePath @(
+        'src/private/shared/Get-KeepAChangelogRepositoryProviderParameterDictionary.ps1'
+    ) | ForEach-Object { . $_.FullName }
+}
+
+Describe 'Get-KeepAChangelogRepositoryProviderParameterDictionary' {
+    It 'creates a RepositoryProvider dynamic parameter with the supported provider values' {
+        $result = Get-KeepAChangelogRepositoryProviderParameterDictionary
+        $parameter = $result['RepositoryProvider']
+        $validateSet = $parameter.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] }
+
+        $parameter.Name | Should -Be 'RepositoryProvider'
+        $parameter.ParameterType | Should -Be ([string])
+        $validateSet.ValidValues | Should -Be @('GitHub', 'GitLab')
+    }
+}

--- a/tests/private/validation/Get-UnreleasedCompareLinkMatch.Tests.ps1
+++ b/tests/private/validation/Get-UnreleasedCompareLinkMatch.Tests.ps1
@@ -9,17 +9,24 @@ BeforeAll {
 }
 
 Describe 'Get-UnreleasedCompareLinkMatch' {
-    It 'extracts the compare prefix and previous release reference' {
-        $match = Get-UnreleasedCompareLinkMatch -Text @'
+    It 'extracts the compare prefix and previous release reference' -ForEach @(
+        @{
+            Prefix = 'https://github.com/example/repo/compare/'
+        }
+        @{
+            Prefix = 'https://gitlab.com/example/repo/-/compare/'
+        }
+    ) {
+        $match = Get-UnreleasedCompareLinkMatch -Text @"
 # Changelog
 
 ## [Unreleased]
 
-[Unreleased]: https://github.com/example/repo/compare/1.5.0...HEAD
-'@
+[Unreleased]: $Prefix`1.5.0...HEAD
+"@
 
         $match.Success | Should -BeTrue
-        $match.Groups['prefix'].Value | Should -Be 'https://github.com/example/repo/compare/'
+        $match.Groups['prefix'].Value | Should -Be $Prefix
         $match.Groups['from'].Value | Should -Be '1.5.0'
     }
 

--- a/tests/public/Initialize-KeepAChangelogFile.Tests.ps1
+++ b/tests/public/Initialize-KeepAChangelogFile.Tests.ps1
@@ -5,25 +5,65 @@ BeforeAll {
     $projectRoot = Get-KeepAChangelogProjectRoot -StartPath $PSScriptRoot
     Import-KeepAChangelogSourceFile -ProjectRoot $projectRoot -RelativePath @(
         'src/private/initialize/*.ps1'
+        'src/private/shared/Get-KeepAChangelogRepositoryLinkData.ps1'
+        'src/private/shared/Get-KeepAChangelogRepositoryProviderParameterDictionary.ps1'
         'src/public/Initialize-KeepAChangelogFile.ps1'
     ) | ForEach-Object { . $_.FullName }
 }
 
 Describe 'Initialize-KeepAChangelogFile' {
-    It 'creates a changelog template with standard headings and an Unreleased compare link when PreviousReleaseReference is provided' {
-        $path = Join-Path $TestDrive 'CHANGELOG.md'
+    It 'exposes RepositoryProvider with the supported provider values' {
+        $command = Get-Command -Name Initialize-KeepAChangelogFile
+        $validateSet = $command.Parameters['RepositoryProvider'].Attributes |
+            Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] }
 
-        $result = Initialize-KeepAChangelogFile `
-            -Path $path `
-            -RepositoryUrl 'https://github.com/example/repo' `
-            -PreviousReleaseReference '1.0.0'
+        $command.Parameters.ContainsKey('RepositoryProvider') | Should -BeTrue
+        $validateSet.ValidValues | Should -Be @('GitHub', 'GitLab')
+    }
+
+    It 'creates a changelog template with standard headings and an Unreleased compare link when PreviousReleaseReference is provided' -ForEach @(
+        @{
+            Name                  = 'GitHub repository URLs'
+            FileName              = 'CHANGELOG-github.md'
+            RepositoryUrl         = 'https://github.com/example/repo'
+            RepositoryProvider    = 'GitHub'
+            ExpectedFooterPattern = '\[Unreleased\]: https://github\.com/example/repo/compare/1\.0\.0\.\.\.HEAD'
+        }
+        @{
+            Name                  = 'GitLab repository URLs'
+            FileName              = 'CHANGELOG-gitlab.md'
+            RepositoryUrl         = 'https://gitlab.com/example/repo'
+            RepositoryProvider    = ''
+            ExpectedFooterPattern = '\[Unreleased\]: https://gitlab\.com/example/repo/-/compare/1\.0\.0\.\.\.HEAD'
+        }
+        @{
+            Name                  = 'self-hosted GitLab repository URLs with an explicit provider'
+            FileName              = 'CHANGELOG-self-hosted-gitlab.md'
+            RepositoryUrl         = 'https://code.example.com/group/project'
+            RepositoryProvider    = 'GitLab'
+            ExpectedFooterPattern = '\[Unreleased\]: https://code\.example\.com/group/project/-/compare/1\.0\.0\.\.\.HEAD'
+        }
+    ) {
+        $path = Join-Path $TestDrive $FileName
+
+        $parameters = @{
+            Path                     = $path
+            RepositoryUrl            = $RepositoryUrl
+            PreviousReleaseReference = '1.0.0'
+        }
+
+        if (-not [string]::IsNullOrWhiteSpace($RepositoryProvider)) {
+            $parameters.RepositoryProvider = $RepositoryProvider
+        }
+
+        $result = Initialize-KeepAChangelogFile @parameters
         $text = Get-Content -LiteralPath $path -Raw
 
         $result.Path | Should -Be $path
         $text | Should -Match '## \[Unreleased\]'
         $text | Should -Match '### Added'
         $text | Should -Match '### Security'
-        $text | Should -Match '\[Unreleased\]: https://github\.com/example/repo/compare/1\.0\.0\.\.\.HEAD'
+        $text | Should -Match $ExpectedFooterPattern
     }
 
     It 'creates a changelog template without footer links when PreviousReleaseReference is omitted' {

--- a/tests/public/Move-UnreleasedChangelog.Tests.ps1
+++ b/tests/public/Move-UnreleasedChangelog.Tests.ps1
@@ -3,13 +3,19 @@ function script:Initialize-TestChangelog {
     param(
         [Parameter(Mandatory)]
         [string]$Path,
-        [string]$PreviousReleaseReference
+        [string]$PreviousReleaseReference,
+        [string]$RepositoryUrl = 'https://github.com/example/repo',
+        [string]$RepositoryProvider
     )
 
     $parameters = @{
         Path          = $Path
-        RepositoryUrl = 'https://github.com/example/repo'
+        RepositoryUrl = $RepositoryUrl
         Force         = $true
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($RepositoryProvider)) {
+        $parameters.RepositoryProvider = $RepositoryProvider
     }
 
     if (-not [string]::IsNullOrWhiteSpace($PreviousReleaseReference)) {
@@ -101,6 +107,15 @@ BeforeAll {
 }
 
 Describe 'Move-UnreleasedChangelog' {
+    It 'exposes RepositoryProvider with the supported provider values' {
+        $command = Get-Command -Name Move-UnreleasedChangelog
+        $validateSet = $command.Parameters['RepositoryProvider'].Attributes |
+            Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] }
+
+        $command.Parameters.ContainsKey('RepositoryProvider') | Should -BeTrue
+        $validateSet.ValidValues | Should -Be @('GitHub', 'GitLab')
+    }
+
     It 'moves unreleased notes into a release section, clears Unreleased, and updates compare links' {
         $caseList = @(
             @{
@@ -218,10 +233,11 @@ $footer
         ([regex]::Matches($updated, '(?m)^\[1\.6\.0\]:').Count) | Should -Be 1
     }
 
-    It 'reuses the last remaining release reference when the same version is released again' {
-        $path = Join-Path $TestDrive 'CHANGELOG.md'
-
-        @'
+    It 'updates compare links from the last remaining release reference for <Name>' -ForEach @(
+        @{
+            Name                   = 're-releasing the same GitHub version'
+            FileName               = 'CHANGELOG-github-rerelease.md'
+            Text                   = @'
 # Changelog
 
 ## [Unreleased]
@@ -238,20 +254,84 @@ $footer
 
 [Unreleased]: https://github.com/example/repo/compare/0.1.0...HEAD
 [0.0.1]: https://github.com/example/repo/compare/develop...0.0.1
-'@ | Set-Content -LiteralPath $path -Encoding utf8
+'@
+            Version                = '0.1.0'
+            Date                   = '2026-05-04'
+            ExpectedPrevious       = '0.0.1'
+            ExpectedReleaseLink    = 'https://github.com/example/repo/compare/0.0.1...0.1.0'
+            ExpectedUnreleasedLink = '\[Unreleased\]: https://github\.com/example/repo/compare/0\.1\.0\.\.\.HEAD'
+            ExpectedVersionLink    = '\[0\.1\.0\]: https://github\.com/example/repo/compare/0\.0\.1\.\.\.0\.1\.0'
+            ForbiddenVersionLink   = '\[0\.1\.0\]: https://github\.com/example/repo/compare/0\.1\.0\.\.\.0\.1\.0'
+        }
+        @{
+            Name                   = 'updating a GitLab footer'
+            FileName               = 'CHANGELOG-gitlab-footer.md'
+            Text                   = @'
+# Changelog
 
-        $result = Move-UnreleasedChangelog -Path $path -Version '0.1.0' -Date '2026-05-04'
+## [Unreleased]
+
+### Fixed
+
+- Fixed CLI parsing.
+
+## [1.5.0] - 2026-04-10
+
+### Added
+
+- Previous release notes.
+
+[Unreleased]: https://gitlab.com/example/repo/-/compare/1.5.0...HEAD
+[1.5.0]: https://gitlab.com/example/repo/-/compare/1.4.0...1.5.0
+'@
+            Version                = '1.6.0'
+            Date                   = '2026-04-30'
+            ExpectedPrevious       = '1.5.0'
+            ExpectedReleaseLink    = 'https://gitlab.com/example/repo/-/compare/1.5.0...1.6.0'
+            ExpectedUnreleasedLink = '\[Unreleased\]: https://gitlab\.com/example/repo/-/compare/1\.6\.0\.\.\.HEAD'
+            ExpectedVersionLink    = '\[1\.6\.0\]: https://gitlab\.com/example/repo/-/compare/1\.5\.0\.\.\.1\.6\.0'
+            ForbiddenVersionLink   = $null
+        }
+    ) {
+        $path = Join-Path $TestDrive $FileName
+
+        $Text | Set-Content -LiteralPath $path -Encoding utf8
+
+        $result = Move-UnreleasedChangelog -Path $path -Version $Version -Date $Date
         $updated = Get-Content -LiteralPath $path -Raw
 
-        $result.PreviousReleaseReference | Should -Be '0.0.1'
-        $result.NewReleaseCompareLink | Should -Be 'https://github.com/example/repo/compare/0.0.1...0.1.0'
-        $updated | Should -Match '\[Unreleased\]: https://github\.com/example/repo/compare/0\.1\.0\.\.\.HEAD'
-        $updated | Should -Match '\[0\.1\.0\]: https://github\.com/example/repo/compare/0\.0\.1\.\.\.0\.1\.0'
-        $updated | Should -Not -Match '\[0\.1\.0\]: https://github\.com/example/repo/compare/0\.1\.0\.\.\.0\.1\.0'
+        $result.PreviousReleaseReference | Should -Be $ExpectedPrevious
+        $result.NewReleaseCompareLink | Should -Be $ExpectedReleaseLink
+        $result.NewReleaseLink | Should -Be $ExpectedReleaseLink
+        $updated | Should -Match $ExpectedUnreleasedLink
+        $updated | Should -Match $ExpectedVersionLink
+
+        if (-not [string]::IsNullOrWhiteSpace($ForbiddenVersionLink)) {
+            $updated | Should -Not -Match $ForbiddenVersionLink
+        }
     }
 
-    It 'adds footer links on the first release when RepositoryUrl is provided' {
-        $path = Join-Path $TestDrive 'CHANGELOG.md'
+    It 'adds footer links on the first release for <Name>' -ForEach @(
+        @{
+            Name                     = 'GitHub repository URLs'
+            FileName                 = 'CHANGELOG.md'
+            RepositoryUrl            = 'https://github.com/example/repo'
+            RepositoryProvider       = ''
+            ExpectedReleaseLink      = 'https://github.com/example/repo/releases/tag/1.0.0'
+            ExpectedUnreleasedFooter = '\[Unreleased\]: https://github\.com/example/repo/compare/1\.0\.0\.\.\.HEAD'
+            ExpectedReleaseFooter    = '\[1\.0\.0\]: https://github\.com/example/repo/releases/tag/1\.0\.0'
+        }
+        @{
+            Name                     = 'self-hosted GitLab repository URLs with an explicit provider'
+            FileName                 = 'CHANGELOG-gitlab-first-release.md'
+            RepositoryUrl            = 'https://code.example.com/group/project'
+            RepositoryProvider       = 'GitLab'
+            ExpectedReleaseLink      = 'https://code.example.com/group/project/-/tags/1.0.0'
+            ExpectedUnreleasedFooter = '\[Unreleased\]: https://code\.example\.com/group/project/-/compare/1\.0\.0\.\.\.HEAD'
+            ExpectedReleaseFooter    = '\[1\.0\.0\]: https://code\.example\.com/group/project/-/tags/1\.0\.0'
+        }
+    ) {
+        $path = Join-Path $TestDrive $FileName
 
         @'
 # Changelog
@@ -263,18 +343,25 @@ $footer
 - Initial release notes.
 '@ | Set-Content -LiteralPath $path -Encoding utf8
 
-        $result = Move-UnreleasedChangelog `
-            -Path $path `
-            -Version '1.0.0' `
-            -Date '2026-05-01' `
-            -RepositoryUrl 'https://github.com/example/repo'
+        $parameters = @{
+            Path          = $path
+            Version       = '1.0.0'
+            Date          = '2026-05-01'
+            RepositoryUrl = $RepositoryUrl
+        }
+
+        if (-not [string]::IsNullOrWhiteSpace($RepositoryProvider)) {
+            $parameters.RepositoryProvider = $RepositoryProvider
+        }
+
+        $result = Move-UnreleasedChangelog @parameters
         $updated = Get-Content -LiteralPath $path -Raw
 
         $result.PreviousReleaseReference | Should -BeNullOrEmpty
-        $result.NewReleaseCompareLink | Should -Be 'https://github.com/example/repo/releases/tag/1.0.0'
-        $result.NewReleaseLink | Should -Be 'https://github.com/example/repo/releases/tag/1.0.0'
-        $updated | Should -Match '\[Unreleased\]: https://github\.com/example/repo/compare/1\.0\.0\.\.\.HEAD'
-        $updated | Should -Match '\[1\.0\.0\]: https://github\.com/example/repo/releases/tag/1\.0\.0'
+        $result.NewReleaseCompareLink | Should -Be $ExpectedReleaseLink
+        $result.NewReleaseLink | Should -Be $ExpectedReleaseLink
+        $updated | Should -Match $ExpectedUnreleasedFooter
+        $updated | Should -Match $ExpectedReleaseFooter
     }
 
     It 'keeps footer links omitted for <Name>' -ForEach @(

--- a/tests/public/Test-KeepAChangelogFile.Tests.ps1
+++ b/tests/public/Test-KeepAChangelogFile.Tests.ps1
@@ -38,6 +38,8 @@ BeforeAll {
     $projectRoot = Get-KeepAChangelogProjectRoot -StartPath $PSScriptRoot
     Import-KeepAChangelogSourceFile -ProjectRoot $projectRoot -RelativePath @(
         'src/private/initialize/*.ps1'
+        'src/private/shared/Get-KeepAChangelogRepositoryLinkData.ps1'
+        'src/private/shared/Get-KeepAChangelogRepositoryProviderParameterDictionary.ps1'
         'src/private/shared/Split-KeepAChangelogText.ps1'
         'src/private/validation/*.ps1'
         'src/public/Initialize-KeepAChangelogFile.ps1'
@@ -162,6 +164,34 @@ Describe 'Test-KeepAChangelogFile' {
         $result.UnreleasedCompareLinkPrefix | Should -BeNullOrEmpty
         $result.PreviousReleaseReference | Should -BeNullOrEmpty
         @($result.ReleaseVersions) | Should -Be @('1.0.0')
+    }
+
+    It 'accepts GitLab compare links in the reference footer' {
+        $path = Join-Path $TestDrive 'CHANGELOG.md'
+
+        @'
+# Changelog
+
+## [Unreleased]
+
+### Added
+
+## [1.0.0] - 2026-04-30
+
+### Added
+
+- Initial release.
+
+[Unreleased]: https://gitlab.com/example/repo/-/compare/1.0.0...HEAD
+[1.0.0]: https://gitlab.com/example/repo/-/tags/1.0.0
+'@ | Set-Content -LiteralPath $path -Encoding utf8
+
+        $result = Test-KeepAChangelogFile -Path $path
+
+        $result.IsValid | Should -BeTrue
+        @($result.Errors).Count | Should -Be 0
+        $result.UnreleasedCompareLinkPrefix | Should -Be 'https://gitlab.com/example/repo/-/compare/'
+        $result.PreviousReleaseReference | Should -Be '1.0.0'
     }
 
     It 'accepts yanked release headings that follow the Keep a Changelog format' {


### PR DESCRIPTION
## Summary
 
 - Added GitLab changelog footer-link support across `Initialize-KeepAChangelogFile`, `Move-UnreleasedChangelog`, and `Test-KeepAChangelogFile`, including self-hosted GitLab support through `-RepositoryProvider GitLab`.
 - Fixed the CodeScene coverage path so the current JaCoCo `artifacts/coverage.xml` flow is used consistently in CI and coverage gating.
 - Improved `Test-KeepAChangelogFile` diagnostics for malformed `## [Unreleased]` headings.
 - Added maintainer-facing Agentic Copilot workflow scaffolding and guidance.
 - This work is currently unreleased on `0.2.6-preview` and will affect the next stable release; there is no separate stable/prerelease behavior change beyond the normal preview-to-stable promotion.
 
 ## Affected area
 
 - [x] Public PowerShell cmdlet behavior
 - [ ] Scaffolding or project layout
 - [x] Build, test, analyzer, or CI behavior
 - [x] Release, changelog, or versioning flow
 - [ ] Contributor documentation
 - [ ] End-user documentation
 - [x] Command help
 - [x] Other
 
 ## Review guidance
 
 - Start with the highest-risk path: GitLab footer-link generation and preservation in `Move-UnreleasedChangelog`, `Initialize-KeepAChangelogFile`, and the shared release/link helpers.
 - Main files/folders changed: `src/public/`, `src/private/release/`, `src/private/shared/`, `src/private/initialize/`, mirrored tests under `tests/`, command help under `docs/KeepAChangelog/en-US/`, and release-facing docs in `CHANGELOG.md` and `RELEASE_NOTE.md`.
 - Trade-offs and follow-up:
   - Existing footer-link shape still takes precedence over explicit provider input, which preserves current changelog behavior safely.
   - `CHANGELOG.md` intentionally keeps the maintainer-facing Agentic Copilot scaffolding entry, while `RELEASE_NOTE.md` stays focused on public cmdlet and workflow changes.
 
 ## Validation
 
 - [x] `Invoke-NovaBuild`
 - [x] `Test-NovaBuild`
 - [x] Targeted validation for the changed path
 - [x] Full repository quality loop
 - [ ] Docs-only change; executable validation not needed
 
 Validation notes:
 
 ```text
 pwsh -NoLogo -NoProfile -Command "./scripts/build/Invoke-ScriptAnalyzerCI.ps1"
 pwsh -NoLogo -NoProfile -Command "Invoke-NovaBuild"
 pwsh -NoLogo -NoProfile -Command "Test-NovaBuild"
 
 Result:
 - PSScriptAnalyzer: no findings
 - Test-NovaBuild: 112 tests passed
 - Coverage: 100% / 99% target
 - CodeScene pre_commit_code_health_safeguard: passed
 ```
 
 ## Documentation and release follow-up
 
 - [x] `README.md` reviewed and updated if needed
 - [x] `CONTRIBUTING.md` reviewed and updated if needed
 - [x] `CHANGELOG.md` reviewed and updated if needed
 - [x] `RELEASE_NOTE.md` reviewed and updated if needed
 - [x] Command help updated if needed
 - [ ] End-user docs updated if needed
 - [ ] No documentation or release-note updates were needed
 
 ## Maintainability, compatibility, and risk
 
 - [x] Maintainability impact considered
 - [x] No breaking change
 - [ ] Breaking change
 - [x] CI or release impact
 
 Risk, rollout, or rollback notes:
 
 ```text
 Risk is low.
 
 - Public API impact is additive: RepositoryProvider is an opt-in parameter for provider-specific footer generation.
 - Existing GitHub behavior remains the default when no provider is supplied and no existing footer shape is available.
 - Existing GitLab footer links continue to be inferred and preserved from the current changelog footer.
 - CI/release impact is limited to aligning CodeScene coverage handling with the current JaCoCo artifact path.
 - Rollback is straightforward: revert the unreleased changes before tagging or publishing; no release automation semantics were changed.
 ```
