### PR TITLE
Add support for Azure DevOps changelog links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Added
 
 - Added repository-scoped Agentic Copilot workflow scaffolding for maintainers, including specialized agents, reusable prompts, instruction files, skills, a streamlined pull request template, updated contribution guidance, and an internal `RELEASE_NOTE.md` placeholder for future interface-facing release summaries.
-- Added native GitLab footer-link support so changelog initialization, validation, and release updates can generate and preserve GitLab `/-/compare/` and `/-/tags/` URLs, including self-hosted GitLab repositories when `-RepositoryProvider GitLab` is supplied.
+- Added provider-aware footer-link support so changelog initialization, validation, and release updates can generate and preserve GitHub, GitLab, and Azure DevOps footer links.
+  - `Initialize-KeepAChangelogFile` and `Move-UnreleasedChangelog` now accept `-RepositoryProvider` when the repository host alone is not enough to identify the provider.
+  - Self-hosted GitLab repositories can use `-RepositoryProvider GitLab` to generate GitLab `/-/compare/` and `/-/tags/` links.
+  - Azure DevOps repositories can use `-RepositoryProvider AzureDevOps`, `-RepositoryTargetReference`, and `-ReleaseReference` to generate `branchCompare` footer links with explicit target and release refs.
 
 ### Changed
 

--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -7,7 +7,10 @@ This file summarizes public cmdlet, CLI, configuration, and migration changes fo
 
 ### Added
 
-- Added native GitLab footer-link support so `Initialize-KeepAChangelogFile` and `Move-UnreleasedChangelog` can use `-RepositoryProvider GitLab` for self-hosted GitLab URLs, while `Test-KeepAChangelogFile` continues to accept GitLab `/-/compare/` links.
+- Added provider-aware footer-link support so `Initialize-KeepAChangelogFile` and `Move-UnreleasedChangelog` can generate GitHub, GitLab, and Azure DevOps footer links with explicit provider hints when needed.
+  - Use `-RepositoryProvider GitLab` for self-hosted GitLab repository URLs.
+  - Use `-RepositoryProvider AzureDevOps` together with `-RepositoryTargetReference`, and `-ReleaseReference` on release moves when the Azure release ref differs from the visible version.
+  - `Test-KeepAChangelogFile` now accepts Azure DevOps `branchCompare` footer links in addition to GitHub and GitLab compare links.
 
 ### Changed
 

--- a/docs/KeepAChangelog/en-US/Initialize-KeepAChangelogFile.md
+++ b/docs/KeepAChangelog/en-US/Initialize-KeepAChangelogFile.md
@@ -20,7 +20,7 @@ Initializes a Keep a Changelog template.
 ### __AllParameterSets
 
 ```text
-PS> Initialize-KeepAChangelogFile [-Path <string>] -RepositoryUrl <string> [-RepositoryProvider <string>] [-PreviousReleaseReference <string>] [-SectionHeading <string[]>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+PS> Initialize-KeepAChangelogFile [-Path <string>] -RepositoryUrl <string> [-RepositoryProvider <string>] [-RepositoryTargetReference <string>] [-PreviousReleaseReference <string>] [-SectionHeading <string[]>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -33,6 +33,14 @@ PS> Initialize-KeepAChangelogFile [-Path <string>] -RepositoryUrl <string> [-Rep
 - a footer `[Unreleased]` compare link when `-PreviousReleaseReference` is provided
 
 Use `-Force` when you want to overwrite an existing file.
+
+When new footer links must be generated:
+
+- GitHub uses `/compare/<previous>...HEAD`
+- GitLab uses `/-/compare/<previous>...HEAD`
+- Azure DevOps uses `/branchCompare?baseVersion=<previous>&targetVersion=<target>&_a=commits`
+
+Use `-RepositoryProvider` when the repository host alone is not enough to identify the provider, and use `-RepositoryTargetReference` for Azure DevOps target refs such as `GBmain` or `GBdevelop`.
 
 ## EXAMPLES
 
@@ -52,6 +60,14 @@ PS> Initialize-KeepAChangelogFile -Path ./CHANGELOG.md -RepositoryUrl https://co
 
 Creates a changelog for a self-hosted GitLab repository by using the explicit provider hint.
 
+### EXAMPLE 3
+
+```text
+PS> Initialize-KeepAChangelogFile -Path ./CHANGELOG.md -RepositoryUrl https://ado.example.com/Org/Project/_git/Tools -RepositoryProvider AzureDevOps -RepositoryTargetReference GBdevelop -PreviousReleaseReference GTv1.5.2
+```
+
+Creates a changelog for Azure DevOps by using the supplied release reference as `baseVersion` and the target ref as `targetVersion`.
+
 ## PARAMETERS
 
 ### -Path
@@ -69,13 +85,23 @@ GitHub repository URLs generate `/compare/` links. GitLab repository URLs like
 
 Optional provider hint used when `-RepositoryUrl` alone is not enough to infer the compare-link format.
 
-Use `GitLab` for self-hosted GitLab URLs that do not contain `gitlab` in the hostname.
+Supported values are `GitHub`, `GitLab`, and `AzureDevOps`.
+
+Use `GitLab` for self-hosted GitLab URLs that do not contain `gitlab` in the hostname. Use `AzureDevOps` for Azure DevOps repository URLs when you want the cmdlet to generate `branchCompare` links explicitly.
+
+### -RepositoryTargetReference
+
+Optional target ref used when Azure DevOps footer links must be generated.
+
+Examples include `GBmain` and `GBdevelop`.
 
 ### -PreviousReleaseReference
 
 Optional release reference used as the starting point for `[Unreleased]`.
 
 Valid values include release tags, commit SHAs, and branch refs such as `main` or `develop`.
+
+For Azure DevOps, this value is used literally as the compare-link `baseVersion`, so pass the exact ref token that your repository expects, for example `GTv1.5.2`.
 
 ### -SectionHeading
 

--- a/docs/KeepAChangelog/en-US/Move-UnreleasedChangelog.md
+++ b/docs/KeepAChangelog/en-US/Move-UnreleasedChangelog.md
@@ -20,7 +20,7 @@ Moves `Unreleased` notes into a versioned release section.
 ### __AllParameterSets
 
 ```text
-PS> Move-UnreleasedChangelog [-Path <string>] -Version <string> [-Date <string>] [-RepositoryUrl <string>] [-RepositoryProvider <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
+PS> Move-UnreleasedChangelog [-Path <string>] -Version <string> [-Date <string>] [-RepositoryUrl <string>] [-RepositoryProvider <string>] [-RepositoryTargetReference <string>] [-ReleaseReference <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -33,12 +33,18 @@ The command:
 2. removes empty `###` subsections from the new release notes
 3. inserts `## [<version>] - <date>` below `## [Unreleased]`
 4. clears `Unreleased` while keeping subsection headings
-5. updates the `[Unreleased]` compare link to `<tag>...HEAD` when a reference-link footer exists or `-RepositoryUrl` is supplied
-6. adds or updates the `[<version>]` release link from the previous release reference to the new tag when footer links are being maintained
+5. updates the `[Unreleased]` compare link when a reference-link footer exists or `-RepositoryUrl` is supplied
+6. adds or updates the `[<version>]` release link from the previous release reference to the new release reference when footer links are being maintained
 
 `-Version` is required. `-Date` is optional. When `-Date` is omitted, the current date is used. When `-Date` is provided, it must use `yyyy-MM-dd` format.
 
 If the changelog has no footer and you want footer links to be created or maintained, pass `-RepositoryUrl`. If you omit it, the release move still runs and the changelog stays without footer links.
+
+When new footer links must be generated:
+
+- GitHub uses `/compare/<previous>...HEAD` and `/releases/tag/<release>`
+- GitLab uses `/-/compare/<previous>...HEAD` and `/-/tags/<release>`
+- Azure DevOps uses `/branchCompare?baseVersion=<previous>&targetVersion=<target>&_a=commits`
 
 The returned object also includes `KeepAChangelogVersion` so CI logs and troubleshooting output
 can show which module version produced the release data.
@@ -61,6 +67,14 @@ PS> Move-UnreleasedChangelog -Path ./CHANGELOG.md -Version 1.0.0 -RepositoryUrl 
 
 Creates the first release and adds GitLab footer links for a self-hosted GitLab repository.
 
+### EXAMPLE 3
+
+```text
+PS> Move-UnreleasedChangelog -Path ./CHANGELOG.md -Version 13.0.4 -RepositoryUrl https://ado.example.com/Org/Project/_git/Tools -RepositoryProvider AzureDevOps -RepositoryTargetReference GBdevelop -ReleaseReference GTv13.0.4
+```
+
+Creates Azure DevOps footer links by using `GTv13.0.4` as the release ref and `GBdevelop` as the ongoing unreleased target ref.
+
 ## PARAMETERS
 
 ### -Path
@@ -79,13 +93,27 @@ Optional release date in `yyyy-MM-dd` format.
 
 Optional repository base URL used to create or maintain footer links when the changelog has no `[Unreleased]` compare link yet.
 
-GitHub repository URLs generate `/compare/` and `/releases/tag/` links. GitLab repository URLs generate `/-/compare/` and `/-/tags/` links.
+GitHub repository URLs generate `/compare/` and `/releases/tag/` links. GitLab repository URLs generate `/-/compare/` and `/-/tags/` links. Azure DevOps repository URLs generate `branchCompare` links.
 
 ### -RepositoryProvider
 
 Optional provider hint used when `-RepositoryUrl` must generate new footer links and the host name does not identify the provider clearly.
 
-Use `GitLab` for self-hosted GitLab repository URLs.
+Supported values are `GitHub`, `GitLab`, and `AzureDevOps`.
+
+Use `GitLab` for self-hosted GitLab repository URLs and `AzureDevOps` when you want the cmdlet to generate Azure DevOps `branchCompare` links explicitly.
+
+### -RepositoryTargetReference
+
+Optional target ref used when Azure DevOps `[Unreleased]` footer links must be generated.
+
+Examples include `GBmain` and `GBdevelop`.
+
+### -ReleaseReference
+
+Optional release ref written into generated footer links when it differs from `-Version`.
+
+Use this for providers such as Azure DevOps when the visible changelog version is `13.0.4` but the compare-link release ref must be something like `GTv13.0.4`.
 
 ### CommonParameters
 

--- a/docs/KeepAChangelog/en-US/Test-KeepAChangelogFile.md
+++ b/docs/KeepAChangelog/en-US/Test-KeepAChangelogFile.md
@@ -29,7 +29,7 @@ PS> Test-KeepAChangelogFile [-Path <string>] [-ThrowOnError] [<CommonParameters>
 
 - the presence of `## [Unreleased]`
 - the `[Unreleased]` compare link when a reference-link footer is present, even if blank lines separate the footer links
-- GitHub `/compare/` and GitLab `/-/compare/` footer-link formats
+- GitHub `/compare/`, GitLab `/-/compare/`, and Azure DevOps `branchCompare?baseVersion=...&targetVersion=...&_a=commits` footer-link formats
 - versioned release headings in `## [<version>] - <date>` format
 - duplicate reference-link labels
 

--- a/src/private/initialize/Get-KeepAChangelogFooterLine.ps1
+++ b/src/private/initialize/Get-KeepAChangelogFooterLine.ps1
@@ -2,8 +2,8 @@ function Get-KeepAChangelogFooterLine {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
-        [string]$RepositoryUrl,
-        [string]$RepositoryProvider,
+        [pscustomobject]$RepositoryState,
+
         [string]$PreviousReleaseReference
     )
 
@@ -11,8 +11,11 @@ function Get-KeepAChangelogFooterLine {
         return $null
     }
 
-    $repositoryLinkData = Get-KeepAChangelogRepositoryLinkData `
-        -RepositoryUrl $RepositoryUrl `
-        -RepositoryProvider $RepositoryProvider
-    return "[Unreleased]: $($repositoryLinkData.UnreleasedCompareLinkPrefix)$PreviousReleaseReference...HEAD"
+    $repositoryLinkData = Get-KeepAChangelogRepositoryLinkData -RepositoryState $RepositoryState
+    $compareLink = Get-KeepAChangelogCompareLink `
+        -RepositoryLinkData $repositoryLinkData `
+        -BaseReference $PreviousReleaseReference `
+        -TargetReference $repositoryLinkData.UnreleasedTargetReference
+
+    return "[Unreleased]: $compareLink"
 }

--- a/src/private/initialize/Get-KeepAChangelogTemplateText.ps1
+++ b/src/private/initialize/Get-KeepAChangelogTemplateText.ps1
@@ -2,16 +2,16 @@ function Get-KeepAChangelogTemplateText {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
-        [string]$RepositoryUrl,
-        [string]$RepositoryProvider,
+        [pscustomobject]$RepositoryState,
+
         [string]$PreviousReleaseReference,
+
         [Parameter(Mandatory)]
         [string[]]$SectionHeading
     )
 
     $footerLine = Get-KeepAChangelogFooterLine `
-        -RepositoryUrl $RepositoryUrl `
-        -RepositoryProvider $RepositoryProvider `
+        -RepositoryState $RepositoryState `
         -PreviousReleaseReference $PreviousReleaseReference
     $lineList = @(
         '# Changelog'

--- a/src/private/release/Assert-KeepAChangelogRelease.ps1
+++ b/src/private/release/Assert-KeepAChangelogRelease.ps1
@@ -18,8 +18,9 @@ function Assert-KeepAChangelogRelease {
     }
 
     return [pscustomobject]@{
-        Version = [string]$Release.Version
-        Date    = [string]$Release.Date
-        Tag     = [string]$Release.Tag
+        Version   = [string]$Release.Version
+        Date      = [string]$Release.Date
+        Tag       = [string]$Release.Tag
+        Reference = if (-not $Release.ContainsKey('Reference') -or [string]::IsNullOrWhiteSpace([string]$Release['Reference'])) { [string]$Release.Tag } else { [string]$Release['Reference'] }
     }
 }

--- a/src/private/release/Get-KeepAChangelogPreviousReleaseReference.ps1
+++ b/src/private/release/Get-KeepAChangelogPreviousReleaseReference.ps1
@@ -10,6 +10,14 @@ function Get-ChangelogReleaseTargetReference {
         return $compareMatch.Groups['target'].Value
     }
 
+    $azureCompareMatch = [regex]::Match(
+        $Link,
+        'branchCompare\?baseVersion=.+?(?:&|&amp;)targetVersion=(?<target>.+?)(?:&|&amp;)_a=commits$'
+    )
+    if ($azureCompareMatch.Success) {
+        return $azureCompareMatch.Groups['target'].Value
+    }
+
     $tagMatch = [regex]::Match($Link, '/(?:releases/tag|-/tags)/(?<target>.+)$')
     if ($tagMatch.Success) {
         return $tagMatch.Groups['target'].Value
@@ -34,7 +42,7 @@ function Get-KeepAChangelogPreviousReleaseReference {
         return $null
     }
 
-    if ($previousReleaseReference -ne $Release.Tag) {
+    if ($previousReleaseReference -ne $Release.Reference) {
         return $previousReleaseReference
     }
 
@@ -45,7 +53,7 @@ function Get-KeepAChangelogPreviousReleaseReference {
         }
 
         $releaseTargetReference = Get-ChangelogReleaseTargetReference -Link $referenceLinkData.LinkMap[$releaseVersion]
-        if (-not [string]::IsNullOrWhiteSpace($releaseTargetReference) -and $releaseTargetReference -ne $Release.Tag) {
+        if (-not [string]::IsNullOrWhiteSpace($releaseTargetReference) -and $releaseTargetReference -ne $Release.Reference) {
             return $releaseTargetReference
         }
     }

--- a/src/private/release/Get-UpdatedChangelogReferenceFooter.ps1
+++ b/src/private/release/Get-UpdatedChangelogReferenceFooter.ps1
@@ -30,20 +30,28 @@ function Get-ChangelogReleaseLink {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
-        [string]$ReleaseTagPrefix,
-        [Parameter(Mandatory)]
-        [string]$UnreleasedCompareLinkPrefix,
+        [pscustomobject]$Context,
         [AllowEmptyString()]
         [string]$PreviousReleaseReference,
         [Parameter(Mandatory)]
-        [string]$ReleaseTag
+        [string]$ReleaseReference
     )
 
     if ([string]::IsNullOrWhiteSpace($PreviousReleaseReference)) {
-        return "$ReleaseTagPrefix$ReleaseTag"
+        if (-not [string]::IsNullOrWhiteSpace($Context.ReleaseTagPrefix)) {
+            return "$($Context.ReleaseTagPrefix)$ReleaseReference"
+        }
+
+        return Get-KeepAChangelogCompareLink `
+            -RepositoryLinkData $Context `
+            -BaseReference $ReleaseReference `
+            -TargetReference $ReleaseReference
     }
 
-    return "$UnreleasedCompareLinkPrefix$PreviousReleaseReference...$ReleaseTag"
+    return Get-KeepAChangelogCompareLink `
+        -RepositoryLinkData $Context `
+        -BaseReference $PreviousReleaseReference `
+        -TargetReference $ReleaseReference
 }
 
 function Add-ChangelogReferenceLabel {
@@ -100,12 +108,14 @@ function Get-UpdatedChangelogReferenceFooter {
         $orderedLabelList.Add('Unreleased')
     }
 
-    $updatedUnreleasedLink = "$($Context.UnreleasedCompareLinkPrefix)$($Release.Tag)...HEAD"
+    $updatedUnreleasedLink = Get-KeepAChangelogCompareLink `
+        -RepositoryLinkData $Context `
+        -BaseReference $Release.Reference `
+        -TargetReference $Context.UnreleasedTargetReference
     $newReleaseLink = Get-ChangelogReleaseLink `
-        -ReleaseTagPrefix $Context.ReleaseTagPrefix `
-        -UnreleasedCompareLinkPrefix $Context.UnreleasedCompareLinkPrefix `
+        -Context $Context `
         -PreviousReleaseReference $Context.PreviousReleaseReference `
-        -ReleaseTag $Release.Tag
+        -ReleaseReference $Release.Reference
     $linkMap['Unreleased'] = $updatedUnreleasedLink
 
     Add-ChangelogReferenceLabel -OrderedLabelList $orderedLabelList -LinkMap $linkMap -Label $Release.Version

--- a/src/private/release/Resolve-KeepAChangelogReleaseData.ps1
+++ b/src/private/release/Resolve-KeepAChangelogReleaseData.ps1
@@ -3,14 +3,16 @@ function Get-KeepAChangelogRepositoryState {
     param(
         [string]$RepositoryUrl,
         [string]$RepositoryProvider,
+        [string]$RepositoryTargetReference,
         [AllowEmptyString()]
         [string]$Footer
     )
 
     return [pscustomobject]@{
-        Footer             = $Footer
-        RepositoryProvider = $RepositoryProvider
-        RepositoryUrl      = $RepositoryUrl
+        Footer                    = $Footer
+        RepositoryProvider        = $RepositoryProvider
+        RepositoryTargetReference = $RepositoryTargetReference
+        RepositoryUrl             = $RepositoryUrl
     }
 }
 
@@ -52,16 +54,23 @@ function Get-KeepAChangelogRepositoryContext {
         return [pscustomobject]@{
             RepositoryUrl               = $null
             UnreleasedCompareLinkPrefix = $null
+            UnreleasedTargetReference   = $null
+            CompareLinkPrefix           = $null
+            CompareLinkSeparator        = $null
+            CompareLinkSuffix           = $null
             ReleaseTagPrefix            = $null
             PreviousReleaseReference    = $null
             ShouldWriteReferenceFooter  = $false
         }
     }
 
-    $repositoryLinkData = Get-KeepAChangelogRepositoryLinkData `
-        -RepositoryUrl $normalizedRepositoryUrl `
-        -RepositoryProvider $RepositoryState.RepositoryProvider `
-        -UnreleasedCompareLinkPrefix $unreleasedCompareLinkPrefix
+    $repositoryLinkData = Get-KeepAChangelogRepositoryLinkData -RepositoryState ([pscustomobject]@{
+            RepositoryUrl             = $normalizedRepositoryUrl
+            RepositoryProvider        = $RepositoryState.RepositoryProvider
+            RepositoryTargetReference = $RepositoryState.RepositoryTargetReference
+            UnreleasedCompareLinkPrefix = $unreleasedCompareLinkPrefix
+            UnreleasedTargetReference = $Validation.UnreleasedTargetReference
+        })
 
     $previousReleaseReference = Get-KeepAChangelogPreviousReleaseReference `
         -Footer $RepositoryState.Footer `
@@ -72,6 +81,9 @@ function Get-KeepAChangelogRepositoryContext {
         RepositoryProvider          = $repositoryLinkData.RepositoryProvider
         RepositoryUrl               = $repositoryLinkData.RepositoryUrl
         UnreleasedCompareLinkPrefix = $repositoryLinkData.UnreleasedCompareLinkPrefix
+        UnreleasedTargetReference   = $repositoryLinkData.UnreleasedTargetReference
+        CompareLinkSeparator        = $repositoryLinkData.CompareLinkSeparator
+        CompareLinkSuffix           = $repositoryLinkData.CompareLinkSuffix
         ReleaseTagPrefix            = $repositoryLinkData.ReleaseTagPrefix
         PreviousReleaseReference    = $previousReleaseReference
         ShouldWriteReferenceFooter  = $true
@@ -131,8 +143,7 @@ function Resolve-KeepAChangelogReleaseData {
         [Parameter(Mandatory)]
         [hashtable]$Release,
 
-        [string]$RepositoryUrl,
-        [string]$RepositoryProvider
+        [pscustomobject]$RepositoryState
     )
 
     $normalizedRelease = Assert-KeepAChangelogRelease -Release $Release
@@ -142,8 +153,9 @@ function Resolve-KeepAChangelogReleaseData {
     Assert-KeepAChangelogReleaseDateOrder -Body $parts.Body -Release $normalizedRelease
     $unreleasedSectionMatch = Get-UnreleasedSectionMatch -Text $parts.Body
     $repositoryState = Get-KeepAChangelogRepositoryState `
-        -RepositoryUrl $RepositoryUrl `
-        -RepositoryProvider $RepositoryProvider `
+        -RepositoryUrl $RepositoryState.RepositoryUrl `
+        -RepositoryProvider $RepositoryState.RepositoryProvider `
+        -RepositoryTargetReference $RepositoryState.RepositoryTargetReference `
         -Footer $parts.Footer
     $repositoryContext = Get-KeepAChangelogRepositoryContext `
         -RepositoryState $repositoryState `

--- a/src/private/shared/Get-KeepAChangelogRepositoryLinkData.ps1
+++ b/src/private/shared/Get-KeepAChangelogRepositoryLinkData.ps1
@@ -1,34 +1,105 @@
-function Test-KeepAChangelogGitLabRepositoryUrl {
-    [CmdletBinding()]
+function Test-KeepAChangelogRepositoryUrlMatch {
     param(
-        [string]$RepositoryUrl
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [string]$RepositoryUrl,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Pattern
     )
 
     if ([string]::IsNullOrWhiteSpace($RepositoryUrl)) {
         return $false
     }
 
-    return $RepositoryUrl -match '^https?://[^/]*gitlab[^/]*/'
+    return $RepositoryUrl -match $Pattern
 }
 
-function Get-KeepAChangelogRepositoryProvider {
-    [CmdletBinding()]
+function Test-KeepAChangelogGitLabRepositoryUrl {
     param(
-        [string]$RepositoryProvider,
-        [string]$RepositoryUrl,
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [string]$RepositoryUrl
+    )
+
+    return Test-KeepAChangelogRepositoryUrlMatch -RepositoryUrl $RepositoryUrl -Pattern 'https?://[^/]*gitlab[^/]*/'
+}
+
+function Test-KeepAChangelogAzureDevOpsRepositoryUrl {
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [string]$RepositoryUrl
+    )
+
+    return Test-KeepAChangelogRepositoryUrlMatch -RepositoryUrl $RepositoryUrl -Pattern '/_git/'
+}
+
+function Get-KeepAChangelogRepositoryProviderSetting {
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('GitHub', 'GitLab', 'AzureDevOps')]
+        [string]$RepositoryProvider
+    )
+
+    $settingsByProvider = @{
+        GitHub = [pscustomobject]@{
+            CompareLinkPrefixSegment      = '/compare/'
+            CompareLinkSeparator          = '...'
+            CompareLinkSuffix             = ''
+            DefaultUnreleasedTargetReference = 'HEAD'
+            ReleaseTagPath                = '/releases/tag/'
+        }
+        GitLab = [pscustomobject]@{
+            CompareLinkPrefixSegment      = '/-/compare/'
+            CompareLinkSeparator          = '...'
+            CompareLinkSuffix             = ''
+            DefaultUnreleasedTargetReference = 'HEAD'
+            ReleaseTagPath                = '/-/tags/'
+        }
+        AzureDevOps = [pscustomobject]@{
+            CompareLinkPrefixSegment      = '/branchCompare?baseVersion='
+            CompareLinkSeparator          = '&targetVersion='
+            CompareLinkSuffix             = '&_a=commits'
+            DefaultUnreleasedTargetReference = $null
+            ReleaseTagPath                = $null
+        }
+    }
+
+    return $settingsByProvider[$RepositoryProvider]
+}
+
+function Get-KeepAChangelogRepositoryProviderFromComparePrefix {
+    param(
+        [AllowNull()]
+        [AllowEmptyString()]
         [string]$UnreleasedCompareLinkPrefix
     )
 
-    if (-not [string]::IsNullOrWhiteSpace($UnreleasedCompareLinkPrefix)) {
-        if ($UnreleasedCompareLinkPrefix.TrimEnd('/') -like '*-/compare') {
-            return 'GitLab'
-        }
-
-        return 'GitHub'
+    if ([string]::IsNullOrWhiteSpace($UnreleasedCompareLinkPrefix)) {
+        return $null
     }
 
-    if (-not [string]::IsNullOrWhiteSpace($RepositoryProvider)) {
-        return $RepositoryProvider
+    if ($UnreleasedCompareLinkPrefix -like '*/branchCompare?baseVersion=*') {
+        return 'AzureDevOps'
+    }
+
+    if ($UnreleasedCompareLinkPrefix -like '*-/compare/*') {
+        return 'GitLab'
+    }
+
+    return 'GitHub'
+}
+
+function Get-KeepAChangelogRepositoryProviderFromUrl {
+    param(
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$RepositoryUrl
+    )
+
+    if (Test-KeepAChangelogAzureDevOpsRepositoryUrl -RepositoryUrl $RepositoryUrl) {
+        return 'AzureDevOps'
     }
 
     if (Test-KeepAChangelogGitLabRepositoryUrl -RepositoryUrl $RepositoryUrl) {
@@ -38,90 +109,146 @@ function Get-KeepAChangelogRepositoryProvider {
     return 'GitHub'
 }
 
-function Get-KeepAChangelogComparePath {
-    [CmdletBinding()]
+function Get-KeepAChangelogRepositoryProvider {
     param(
-        [Parameter(Mandatory)]
-        [string]$RepositoryProvider
-    )
-
-    if ($RepositoryProvider -eq 'GitLab') {
-        return '/-/compare/'
-    }
-
-    return '/compare/'
-}
-
-function Get-KeepAChangelogReleaseTagPath {
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory)]
-        [string]$RepositoryProvider
-    )
-
-    if ($RepositoryProvider -eq 'GitLab') {
-        return '/-/tags/'
-    }
-
-    return '/releases/tag/'
-}
-
-function Resolve-KeepAChangelogRepositoryUrlFromComparePrefix {
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory)]
-        [string]$UnreleasedCompareLinkPrefix,
-        [Parameter(Mandatory)]
-        [string]$ComparePath
-    )
-
-    $normalizedPrefix = $UnreleasedCompareLinkPrefix.TrimEnd('/')
-    $compareSuffix = $ComparePath.TrimEnd('/')
-
-    return $normalizedPrefix.Substring(0, $normalizedPrefix.Length - $compareSuffix.Length)
-}
-
-function Get-KeepAChangelogRepositoryLinkData {
-    [CmdletBinding()]
-    param(
+        [AllowNull()]
+        [AllowEmptyString()]
         [string]$RepositoryUrl,
+
+        [AllowNull()]
+        [AllowEmptyString()]
         [string]$RepositoryProvider,
+
+        [AllowNull()]
+        [AllowEmptyString()]
         [string]$UnreleasedCompareLinkPrefix
     )
 
-    if ([string]::IsNullOrWhiteSpace($RepositoryUrl) -and [string]::IsNullOrWhiteSpace($UnreleasedCompareLinkPrefix)) {
-        return [pscustomobject]@{
-            RepositoryProvider          = $null
-            RepositoryUrl               = $null
-            UnreleasedCompareLinkPrefix = $null
-            ReleaseTagPrefix            = $null
-        }
+    $detectedProvider = Get-KeepAChangelogRepositoryProviderFromComparePrefix -UnreleasedCompareLinkPrefix $UnreleasedCompareLinkPrefix
+    if ($null -ne $detectedProvider) {
+        return $detectedProvider
     }
 
-    $normalizedRepositoryUrl = if ([string]::IsNullOrWhiteSpace($RepositoryUrl)) {
-        $null
-    }
-    else {
-        $RepositoryUrl.TrimEnd('/')
+    if (-not [string]::IsNullOrWhiteSpace($RepositoryProvider)) {
+        return $RepositoryProvider
     }
 
-    $resolvedRepositoryProvider = Get-KeepAChangelogRepositoryProvider `
-        -RepositoryProvider $RepositoryProvider `
-        -RepositoryUrl $normalizedRepositoryUrl `
-        -UnreleasedCompareLinkPrefix $UnreleasedCompareLinkPrefix
-    $comparePath = Get-KeepAChangelogComparePath `
-        -RepositoryProvider $resolvedRepositoryProvider
+    return Get-KeepAChangelogRepositoryProviderFromUrl -RepositoryUrl $RepositoryUrl
+}
 
-    if ([string]::IsNullOrWhiteSpace($normalizedRepositoryUrl)) {
-        $normalizedRepositoryUrl = Resolve-KeepAChangelogRepositoryUrlFromComparePrefix `
-            -UnreleasedCompareLinkPrefix $UnreleasedCompareLinkPrefix `
-            -ComparePath $comparePath
+function Get-KeepAChangelogUnreleasedTargetReference {
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('GitHub', 'GitLab', 'AzureDevOps')]
+        [string]$RepositoryProvider,
+
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$RepositoryTargetReference,
+
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$UnreleasedTargetReference
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($UnreleasedTargetReference)) {
+        return $UnreleasedTargetReference
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($RepositoryTargetReference)) {
+        return $RepositoryTargetReference
+    }
+
+    return (Get-KeepAChangelogRepositoryProviderSetting -RepositoryProvider $RepositoryProvider).DefaultUnreleasedTargetReference
+}
+
+function Resolve-KeepAChangelogRepositoryUrlFromComparePrefix {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$UnreleasedCompareLinkPrefix,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('GitHub', 'GitLab', 'AzureDevOps')]
+        [string]$RepositoryProvider
+    )
+
+    $compareLinkPrefixSegment = (Get-KeepAChangelogRepositoryProviderSetting -RepositoryProvider $RepositoryProvider).CompareLinkPrefixSegment
+    return $UnreleasedCompareLinkPrefix.Substring(0, $UnreleasedCompareLinkPrefix.Length - $compareLinkPrefixSegment.Length)
+}
+
+function Get-KeepAChangelogCompareLink {
+    param(
+        [Parameter(Mandatory = $true)]
+        [pscustomobject]$RepositoryLinkData,
+
+        [Parameter(Mandatory = $true)]
+        [string]$BaseReference,
+
+        [Parameter(Mandatory = $true)]
+        [string]$TargetReference
+    )
+
+    return '{0}{1}{2}{3}{4}' -f `
+        $RepositoryLinkData.UnreleasedCompareLinkPrefix, `
+        $BaseReference, `
+        $RepositoryLinkData.CompareLinkSeparator, `
+        $TargetReference, `
+        $RepositoryLinkData.CompareLinkSuffix
+}
+
+function Get-KeepAChangelogRepositoryLinkData {
+    param(
+        [Parameter(Mandatory = $true)]
+        [pscustomobject]$RepositoryState
+    )
+
+    $repositoryUrl = $RepositoryState.RepositoryUrl
+    $repositoryProvider = $RepositoryState.RepositoryProvider
+    $repositoryTargetReference = $RepositoryState.RepositoryTargetReference
+    $unreleasedCompareLinkPrefix = $RepositoryState.UnreleasedCompareLinkPrefix
+    $unreleasedTargetReference = $RepositoryState.UnreleasedTargetReference
+
+    if ([string]::IsNullOrWhiteSpace($repositoryUrl) -and [string]::IsNullOrWhiteSpace($unreleasedCompareLinkPrefix)) {
+        return $null
+    }
+
+    $resolvedProvider = Get-KeepAChangelogRepositoryProvider `
+        -RepositoryUrl $repositoryUrl `
+        -RepositoryProvider $repositoryProvider `
+        -UnreleasedCompareLinkPrefix $unreleasedCompareLinkPrefix
+    $providerSettings = Get-KeepAChangelogRepositoryProviderSetting -RepositoryProvider $resolvedProvider
+
+    if ([string]::IsNullOrWhiteSpace($repositoryUrl)) {
+        $repositoryUrl = Resolve-KeepAChangelogRepositoryUrlFromComparePrefix `
+            -UnreleasedCompareLinkPrefix $unreleasedCompareLinkPrefix `
+            -RepositoryProvider $resolvedProvider
+    }
+
+    if ([string]::IsNullOrWhiteSpace($unreleasedCompareLinkPrefix)) {
+        $unreleasedCompareLinkPrefix = '{0}{1}' -f $repositoryUrl, $providerSettings.CompareLinkPrefixSegment
+    }
+
+    $resolvedTargetReference = Get-KeepAChangelogUnreleasedTargetReference `
+        -RepositoryProvider $resolvedProvider `
+        -RepositoryTargetReference $repositoryTargetReference `
+        -UnreleasedTargetReference $unreleasedTargetReference
+
+    if (($resolvedProvider -eq 'AzureDevOps') -and [string]::IsNullOrWhiteSpace($resolvedTargetReference)) {
+        throw 'RepositoryTargetReference is required when AzureDevOps footer links must be generated.'
+    }
+
+    $releaseTagPrefix = $null
+    if ($null -ne $providerSettings.ReleaseTagPath) {
+        $releaseTagPrefix = '{0}{1}' -f $repositoryUrl, $providerSettings.ReleaseTagPath
     }
 
     return [pscustomobject]@{
-        RepositoryProvider          = $resolvedRepositoryProvider
-        RepositoryUrl               = $normalizedRepositoryUrl
-        UnreleasedCompareLinkPrefix = "$normalizedRepositoryUrl$comparePath"
-        ReleaseTagPrefix            = "$normalizedRepositoryUrl$(Get-KeepAChangelogReleaseTagPath -RepositoryProvider $resolvedRepositoryProvider)"
+        RepositoryUrl            = $repositoryUrl
+        RepositoryProvider       = $resolvedProvider
+        UnreleasedCompareLinkPrefix = $unreleasedCompareLinkPrefix
+        CompareLinkSeparator     = $providerSettings.CompareLinkSeparator
+        CompareLinkSuffix        = $providerSettings.CompareLinkSuffix
+        UnreleasedTargetReference = $resolvedTargetReference
+        ReleaseTagPrefix         = $releaseTagPrefix
     }
 }

--- a/src/private/shared/Get-KeepAChangelogRepositoryProviderParameterDictionary.ps1
+++ b/src/private/shared/Get-KeepAChangelogRepositoryProviderParameterDictionary.ps1
@@ -1,18 +1,57 @@
-function Get-KeepAChangelogRepositoryProviderParameterDictionary {
+function Get-KeepAChangelogRuntimeDefinedParameter {
     [CmdletBinding()]
-    param()
+    param(
+        [Parameter(Mandatory)]
+        [string]$Name,
+        [Parameter(Mandatory)]
+        [type]$ParameterType,
+        [string[]]$ValidateSetValue
+    )
 
     $attribute = [System.Management.Automation.ParameterAttribute]::new()
     $attributeCollection = [System.Collections.ObjectModel.Collection[System.Attribute]]::new()
     $attributeCollection.Add($attribute)
-    $attributeCollection.Add([System.Management.Automation.ValidateSetAttribute]::new('GitHub', 'GitLab'))
 
-    $parameter = [System.Management.Automation.RuntimeDefinedParameter]::new(
-        'RepositoryProvider',
-        [string],
+    if ($null -ne $ValidateSetValue -and $ValidateSetValue.Count -gt 0) {
+        $attributeCollection.Add([System.Management.Automation.ValidateSetAttribute]::new($ValidateSetValue))
+    }
+
+    return [System.Management.Automation.RuntimeDefinedParameter]::new(
+        $Name,
+        $ParameterType,
         $attributeCollection
     )
+}
+
+function Get-KeepAChangelogRepositoryProviderParameterDictionary {
+    [CmdletBinding()]
+    param(
+        [switch]$IncludeReleaseReference,
+        [switch]$IncludeRepositoryTargetReference
+    )
+
     $parameterDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
-    $parameterDictionary.Add('RepositoryProvider', $parameter)
+    $parameterDictionary.Add(
+        'RepositoryProvider',
+        (Get-KeepAChangelogRuntimeDefinedParameter `
+            -Name 'RepositoryProvider' `
+            -ParameterType ([string]) `
+            -ValidateSetValue @('GitHub', 'GitLab', 'AzureDevOps'))
+    )
+
+    if ($IncludeRepositoryTargetReference) {
+        $parameterDictionary.Add(
+            'RepositoryTargetReference',
+            (Get-KeepAChangelogRuntimeDefinedParameter -Name 'RepositoryTargetReference' -ParameterType ([string]))
+        )
+    }
+
+    if ($IncludeReleaseReference) {
+        $parameterDictionary.Add(
+            'ReleaseReference',
+            (Get-KeepAChangelogRuntimeDefinedParameter -Name 'ReleaseReference' -ParameterType ([string]))
+        )
+    }
+
     return $parameterDictionary
 }

--- a/src/private/validation/Get-KeepAChangelogUnreleasedCompareLinkData.ps1
+++ b/src/private/validation/Get-KeepAChangelogUnreleasedCompareLinkData.ps1
@@ -11,6 +11,7 @@ function Get-KeepAChangelogUnreleasedCompareLinkData {
 
     $result = [pscustomobject]@{
         UnreleasedCompareLinkPrefix = $null
+        UnreleasedTargetReference   = $null
         PreviousReleaseReference    = $null
     }
 
@@ -18,8 +19,17 @@ function Get-KeepAChangelogUnreleasedCompareLinkData {
         return $result
     }
 
-    $pattern = '(?m)^\[Unreleased\]:\s*(?<prefix>\S+/compare/)(?<from>.+?)\.\.\.HEAD\s*$'
-    $matchList = [regex]::Matches($Footer, $pattern)
+    $patternList = @(
+        '(?m)^\[Unreleased\]:\s*(?<prefix>\S+/(?:compare|-/compare)/)(?<from>.+?)\.\.\.(?<target>HEAD)\s*$',
+        '(?m)^\[Unreleased\]:\s*(?<prefix>\S+/branchCompare\?baseVersion=)(?<from>.+?)(?:&|&amp;)targetVersion=(?<target>.+?)(?:&|&amp;)_a=commits\s*$'
+    )
+    $matchList = [System.Collections.Generic.List[System.Text.RegularExpressions.Match]]::new()
+
+    foreach ($pattern in $patternList) {
+        foreach ($match in [regex]::Matches($Footer, $pattern)) {
+            $matchList.Add($match)
+        }
+    }
 
     if ($matchList.Count -eq 0) {
         $ErrorList.Add('Could not find an [Unreleased] compare link in CHANGELOG.md.')
@@ -33,6 +43,7 @@ function Get-KeepAChangelogUnreleasedCompareLinkData {
     $match = $matchList[0]
     return [pscustomobject]@{
         UnreleasedCompareLinkPrefix = $match.Groups['prefix'].Value
+        UnreleasedTargetReference   = $match.Groups['target'].Value
         PreviousReleaseReference    = $match.Groups['from'].Value
     }
 }

--- a/src/private/validation/Get-KeepAChangelogValidationResult.ps1
+++ b/src/private/validation/Get-KeepAChangelogValidationResult.ps1
@@ -31,6 +31,7 @@ function Get-KeepAChangelogValidationResult {
         IsValid                     = ($errorList.Count -eq 0)
         Errors                      = @($errorList.ToArray())
         UnreleasedCompareLinkPrefix = $unreleasedCompareLinkData.UnreleasedCompareLinkPrefix
+        UnreleasedTargetReference   = $unreleasedCompareLinkData.UnreleasedTargetReference
         PreviousReleaseReference    = $unreleasedCompareLinkData.PreviousReleaseReference
         ReleaseVersions             = @($releaseVersionList.ToArray())
     }

--- a/src/private/validation/Get-UnreleasedCompareLinkMatch.ps1
+++ b/src/private/validation/Get-UnreleasedCompareLinkMatch.ps1
@@ -5,10 +5,21 @@ function Get-UnreleasedCompareLinkMatch {
         [string]$Text
     )
 
-    $pattern = '(?m)^\[Unreleased\]:\s*(?<prefix>\S+/compare/)(?<from>.+?)\.\.\.HEAD\s*$'
-    $match = [regex]::Match($Text, $pattern)
+    $patternList = @(
+        '(?m)^\[Unreleased\]:\s*(?<prefix>\S+/(?:compare|-/compare)/)(?<from>.+?)\.\.\.(?<target>HEAD)\s*$',
+        '(?m)^\[Unreleased\]:\s*(?<prefix>\S+/branchCompare\?baseVersion=)(?<from>.+?)(?:&|&amp;)targetVersion=(?<target>.+?)(?:&|&amp;)_a=commits\s*$'
+    )
+    $match = $null
 
-    if (-not $match.Success) {
+    foreach ($pattern in $patternList) {
+        $candidateMatch = [regex]::Match($Text, $pattern)
+        if ($candidateMatch.Success) {
+            $match = $candidateMatch
+            break
+        }
+    }
+
+    if ($null -eq $match -or -not $match.Success) {
         throw 'Could not find an [Unreleased] compare link in CHANGELOG.md.'
     }
 

--- a/src/public/Initialize-KeepAChangelogFile.ps1
+++ b/src/public/Initialize-KeepAChangelogFile.ps1
@@ -15,16 +15,23 @@ function Initialize-KeepAChangelogFile {
     )
 
     dynamicparam {
-        return Get-KeepAChangelogRepositoryProviderParameterDictionary
+        return Get-KeepAChangelogRepositoryProviderParameterDictionary -IncludeRepositoryTargetReference
     }
 
     begin {
         Assert-KeepAChangelogInitialization -Path $Path -RepositoryUrl $RepositoryUrl -Force $Force.IsPresent
         $normalizedRepositoryUrl = $RepositoryUrl.TrimEnd('/')
         $repositoryProvider = $PSBoundParameters['RepositoryProvider']
+        $repositoryTargetReference = $PSBoundParameters['RepositoryTargetReference']
+        $repositoryState = [pscustomobject]@{
+            RepositoryUrl             = $normalizedRepositoryUrl
+            RepositoryProvider        = $repositoryProvider
+            RepositoryTargetReference = $repositoryTargetReference
+            UnreleasedCompareLinkPrefix = ''
+            UnreleasedTargetReference = ''
+        }
         $template = Get-KeepAChangelogTemplateText `
-            -RepositoryUrl $normalizedRepositoryUrl `
-            -RepositoryProvider $repositoryProvider `
+            -RepositoryState $repositoryState `
             -PreviousReleaseReference $PreviousReleaseReference `
             -SectionHeading $SectionHeading
 

--- a/src/public/Move-UnreleasedChangelog.ps1
+++ b/src/public/Move-UnreleasedChangelog.ps1
@@ -13,7 +13,9 @@ function Move-UnreleasedChangelog {
     )
 
     dynamicparam {
-        return Get-KeepAChangelogRepositoryProviderParameterDictionary
+        return Get-KeepAChangelogRepositoryProviderParameterDictionary `
+            -IncludeRepositoryTargetReference `
+            -IncludeReleaseReference
     }
 
     begin {
@@ -26,19 +28,25 @@ function Move-UnreleasedChangelog {
         }
 
         $releaseDate = Resolve-KeepAChangelogReleaseDate -Date $Date
+        $releaseReference = $PSBoundParameters['ReleaseReference']
         $release = @{
-            Version = $Version
-            Date    = $releaseDate
-            Tag     = $Version
+            Version   = $Version
+            Date      = $releaseDate
+            Tag       = $Version
+            Reference = if ([string]::IsNullOrWhiteSpace($releaseReference)) { $Version } else { $releaseReference }
         }
 
         $repositoryProvider = $PSBoundParameters['RepositoryProvider']
+        $repositoryTargetReference = $PSBoundParameters['RepositoryTargetReference']
+        $repositoryState = Get-KeepAChangelogRepositoryState `
+            -RepositoryUrl $RepositoryUrl `
+            -RepositoryProvider $repositoryProvider `
+            -RepositoryTargetReference $repositoryTargetReference
         $text = Get-Content -LiteralPath $Path -Raw
         $result = Resolve-KeepAChangelogReleaseData `
             -Text $text `
             -Release $release `
-            -RepositoryUrl $RepositoryUrl `
-            -RepositoryProvider $repositoryProvider
+            -RepositoryState $repositoryState
         $result | Add-Member -NotePropertyName KeepAChangelogVersion -NotePropertyValue (Get-KeepAChangelogModuleVersion) -Force
         $targetVersion = $result.Release.Version
 

--- a/tests/private/initialize/Get-KeepAChangelogFooterLine.Tests.ps1
+++ b/tests/private/initialize/Get-KeepAChangelogFooterLine.Tests.ps1
@@ -14,25 +14,46 @@ Describe 'Get-KeepAChangelogFooterLine' {
         @{
             RepositoryUrl = 'https://github.com/example/repo'
             RepositoryProvider = 'GitHub'
+            RepositoryTargetReference = ''
             PreviousReleaseReference = '1.0.0'
             ExpectedFooterLine = '[Unreleased]: https://github.com/example/repo/compare/1.0.0...HEAD'
         }
         @{
             RepositoryUrl = 'https://code.example.com/group/project'
             RepositoryProvider = 'GitLab'
+            RepositoryTargetReference = ''
             PreviousReleaseReference = '1.0.0'
             ExpectedFooterLine = '[Unreleased]: https://code.example.com/group/project/-/compare/1.0.0...HEAD'
         }
+        @{
+            RepositoryUrl = 'https://ado.example.com/Org/Project/_git/Tools'
+            RepositoryProvider = 'AzureDevOps'
+            RepositoryTargetReference = 'GBdevelop'
+            PreviousReleaseReference = 'GTv1.0.0'
+            ExpectedFooterLine = '[Unreleased]: https://ado.example.com/Org/Project/_git/Tools/branchCompare?baseVersion=GTv1.0.0&targetVersion=GBdevelop&_a=commits'
+        }
     ) {
+        $repositoryState = [pscustomobject]@{
+            RepositoryUrl             = $RepositoryUrl
+            RepositoryProvider        = $RepositoryProvider
+            RepositoryTargetReference = $RepositoryTargetReference
+            UnreleasedCompareLinkPrefix = ''
+            UnreleasedTargetReference = ''
+        }
         $result = Get-KeepAChangelogFooterLine `
-            -RepositoryUrl $RepositoryUrl `
-            -RepositoryProvider $RepositoryProvider `
+            -RepositoryState $repositoryState `
             -PreviousReleaseReference $PreviousReleaseReference
 
         $result | Should -Be $ExpectedFooterLine
     }
 
     It 'returns null when PreviousReleaseReference is omitted' {
-        Get-KeepAChangelogFooterLine -RepositoryUrl 'https://github.com/example/repo' | Should -BeNullOrEmpty
+        Get-KeepAChangelogFooterLine -RepositoryState ([pscustomobject]@{
+                RepositoryUrl             = 'https://github.com/example/repo'
+                RepositoryProvider        = 'GitHub'
+                RepositoryTargetReference = ''
+                UnreleasedCompareLinkPrefix = ''
+                UnreleasedTargetReference = ''
+            }) | Should -BeNullOrEmpty
     }
 }

--- a/tests/private/initialize/Get-KeepAChangelogTemplateText.Tests.ps1
+++ b/tests/private/initialize/Get-KeepAChangelogTemplateText.Tests.ps1
@@ -11,12 +11,34 @@ BeforeAll {
 
 Describe 'Get-KeepAChangelogTemplateText' {
     It 'includes a GitLab compare footer when the explicit provider is GitLab' {
+        $repositoryState = [pscustomobject]@{
+            RepositoryUrl             = 'https://code.example.com/group/project'
+            RepositoryProvider        = 'GitLab'
+            RepositoryTargetReference = ''
+            UnreleasedCompareLinkPrefix = ''
+            UnreleasedTargetReference = ''
+        }
         $result = Get-KeepAChangelogTemplateText `
-            -RepositoryUrl 'https://code.example.com/group/project' `
-            -RepositoryProvider 'GitLab' `
+            -RepositoryState $repositoryState `
             -PreviousReleaseReference '1.0.0' `
             -SectionHeading @('Added', 'Fixed')
 
         $result | Should -Match '\[Unreleased\]: https://code\.example\.com/group/project/-/compare/1\.0\.0\.\.\.HEAD'
+    }
+
+    It 'includes an Azure DevOps compare footer when the explicit target reference is supplied' {
+        $repositoryState = [pscustomobject]@{
+            RepositoryUrl             = 'https://ado.example.com/Org/Project/_git/Tools'
+            RepositoryProvider        = 'AzureDevOps'
+            RepositoryTargetReference = 'GBdevelop'
+            UnreleasedCompareLinkPrefix = ''
+            UnreleasedTargetReference = ''
+        }
+        $result = Get-KeepAChangelogTemplateText `
+            -RepositoryState $repositoryState `
+            -PreviousReleaseReference 'GTv1.0.0' `
+            -SectionHeading @('Added', 'Fixed')
+
+        $result | Should -Match '\[Unreleased\]: https://ado\.example\.com/Org/Project/_git/Tools/branchCompare\?baseVersion=GTv1\.0\.0&targetVersion=GBdevelop&_a=commits'
     }
 }

--- a/tests/private/release/Assert-KeepAChangelogRelease.Tests.ps1
+++ b/tests/private/release/Assert-KeepAChangelogRelease.Tests.ps1
@@ -19,6 +19,7 @@ Describe 'Assert-KeepAChangelogRelease' {
         $result.Version | Should -Be '1.0.0'
         $result.Date | Should -Be '2026-05-03'
         $result.Tag | Should -Be '1.0.0'
+        $result.Reference | Should -Be '1.0.0'
     }
 
     It 'validates required release fields' {

--- a/tests/private/release/Get-KeepAChangelogPreviousReleaseReference.Tests.ps1
+++ b/tests/private/release/Get-KeepAChangelogPreviousReleaseReference.Tests.ps1
@@ -11,12 +11,22 @@ BeforeAll {
 
 Describe 'Get-KeepAChangelogPreviousReleaseReference' {
     It 'extracts the target from release tag links' -ForEach @(
-        'https://github.com/example/repo/releases/tag/1.0.0'
-        'https://gitlab.com/example/repo/-/tags/1.0.0'
+        @{
+            Link           = 'https://github.com/example/repo/releases/tag/1.0.0'
+            ExpectedTarget = '1.0.0'
+        }
+        @{
+            Link           = 'https://gitlab.com/example/repo/-/tags/1.0.0'
+            ExpectedTarget = '1.0.0'
+        }
+        @{
+            Link           = 'https://ado.example.com/Org/Project/_git/Tools/branchCompare?baseVersion=GTv0.9.0&targetVersion=GTv1.0.0&_a=commits'
+            ExpectedTarget = 'GTv1.0.0'
+        }
     ) {
-        $result = Get-ChangelogReleaseTargetReference -Link $_
+        $result = Get-ChangelogReleaseTargetReference -Link $Link
 
-        $result | Should -Be '1.0.0'
+        $result | Should -Be $ExpectedTarget
     }
 
     It 'returns null when a link is not a compare or tag link' {
@@ -33,7 +43,8 @@ Describe 'Get-KeepAChangelogPreviousReleaseReference' {
                 ReleaseVersions          = @()
             }) `
             -Release ([pscustomobject]@{
-                Tag = '1.0.0'
+                Tag       = '1.0.0'
+                Reference = '1.0.0'
             })
 
         $result | Should -Be '0.9.0'
@@ -49,9 +60,27 @@ Describe 'Get-KeepAChangelogPreviousReleaseReference' {
                 ReleaseVersions          = @('0.9.0')
             }) `
             -Release ([pscustomobject]@{
-                Tag = '1.0.0'
+                Tag       = '1.0.0'
+                Reference = '1.0.0'
             })
 
         $result | Should -BeNullOrEmpty
+    }
+
+    It 'returns the previous Azure DevOps release reference when it differs from the current release reference' {
+        $result = Get-KeepAChangelogPreviousReleaseReference `
+            -Footer @'
+[13.0.3]: https://ado.example.com/Org/Project/_git/Tools/branchCompare?baseVersion=GTv13.0.2&targetVersion=GTv13.0.3&_a=commits
+'@ `
+            -Validation ([pscustomobject]@{
+                PreviousReleaseReference = 'GTv13.0.4'
+                ReleaseVersions          = @('13.0.3')
+            }) `
+            -Release ([pscustomobject]@{
+                Tag       = '13.0.4'
+                Reference = 'GTv13.0.4'
+            })
+
+        $result | Should -Be 'GTv13.0.3'
     }
 }

--- a/tests/private/release/Get-UpdatedChangelogReferenceFooter.Tests.ps1
+++ b/tests/private/release/Get-UpdatedChangelogReferenceFooter.Tests.ps1
@@ -4,6 +4,7 @@ BeforeAll {
 
     $projectRoot = Get-KeepAChangelogProjectRoot -StartPath $PSScriptRoot
     Import-KeepAChangelogSourceFile -ProjectRoot $projectRoot -RelativePath @(
+        'src/private/shared/Get-KeepAChangelogRepositoryLinkData.ps1'
         'src/private/release/Get-UpdatedChangelogReferenceFooter.ps1'
     ) | ForEach-Object { . $_.FullName }
 }
@@ -13,24 +14,41 @@ Describe 'Get-UpdatedChangelogReferenceFooter' {
         @{
             Prefix         = 'https://github.com/example/repo/compare/'
             ReleaseTagLink = 'https://github.com/example/repo/releases/tag/1.0.0'
+            Target         = 'HEAD'
         }
         @{
             Prefix         = 'https://gitlab.com/example/repo/-/compare/'
             ReleaseTagLink = 'https://gitlab.com/example/repo/-/tags/1.0.0'
+            Target         = 'HEAD'
+        }
+        @{
+            Prefix         = 'https://ado.example.com/Org/Project/_git/Tools/branchCompare?baseVersion='
+            ReleaseTagLink = 'https://ado.example.com/Org/Project/_git/Tools/branchCompare?baseVersion=GTv1.0.0&targetVersion=GTv1.0.0&_a=commits'
+            Target         = 'GBdevelop'
         }
     ) {
         $result = Get-UpdatedChangelogReferenceFooter `
             -Footer '' `
             -Release ([pscustomobject]@{
-                Version = '1.0.0'
-                Tag     = '1.0.0'
+                Version   = '1.0.0'
+                Tag       = '1.0.0'
+                Reference = if ($ReleaseTagLink -like '*GTv1.0.0*') { 'GTv1.0.0' } else { '1.0.0' }
             }) `
             -Context ([pscustomobject]@{
                 RepositoryUrl               = $null
-                ReleaseTagPrefix            = $ReleaseTagLink -replace '1.0.0$', ''
+                CompareLinkPrefix           = $Prefix
+                CompareLinkSeparator        = if ($Prefix -like '*branchCompare?baseVersion=*') { '&targetVersion=' } else { '...' }
+                CompareLinkSuffix           = if ($Prefix -like '*branchCompare?baseVersion=*') { '&_a=commits' } else { '' }
+                ReleaseTagPrefix            = if ($Prefix -like '*branchCompare?baseVersion=*') { $null } else { $ReleaseTagLink -replace '1.0.0$', '' }
                 UnreleasedCompareLinkPrefix = $Prefix
+                UnreleasedTargetReference   = $Target
                 PreviousReleaseReference    = ''
             })
+
+        if ($Prefix -like '*branchCompare?baseVersion=*') {
+            $result.Footer | Should -Be "[Unreleased]: $($Prefix)GTv1.0.0&targetVersion=GBdevelop&_a=commits`n[1.0.0]: $ReleaseTagLink"
+            return
+        }
 
         $result.Footer | Should -Be "[Unreleased]: $($Prefix)1.0.0...HEAD`n[1.0.0]: $ReleaseTagLink"
     }

--- a/tests/private/release/Resolve-KeepAChangelogReleaseData.Tests.ps1
+++ b/tests/private/release/Resolve-KeepAChangelogReleaseData.Tests.ps1
@@ -20,7 +20,11 @@ Describe 'Resolve-KeepAChangelogReleaseData' {
                 Version = '1.0.0'
                 Date    = '2026-05-03'
                 Tag     = '1.0.0'
-            }
+            } -RepositoryState ([pscustomobject]@{
+                    RepositoryUrl             = ''
+                    RepositoryProvider        = ''
+                    RepositoryTargetReference = ''
+                })
         }
         catch {
             $errorMessage = $_.Exception.Message
@@ -42,7 +46,11 @@ Describe 'Resolve-KeepAChangelogReleaseData' {
             Version = '1.0.0'
             Date    = '2026-05-03'
             Tag     = '1.0.0'
-        } -RepositoryUrl 'https://gitlab.com/example/repo'
+        } -RepositoryState ([pscustomobject]@{
+                RepositoryUrl             = 'https://gitlab.com/example/repo'
+                RepositoryProvider        = ''
+                RepositoryTargetReference = ''
+            })
 
         $result.UnreleasedCompareLinkPrefix | Should -Be 'https://gitlab.com/example/repo/-/compare/'
         $result.UpdatedUnreleasedLink | Should -Be 'https://gitlab.com/example/repo/-/compare/1.0.0...HEAD'
@@ -62,10 +70,39 @@ Describe 'Resolve-KeepAChangelogReleaseData' {
             Version = '1.0.0'
             Date    = '2026-05-03'
             Tag     = '1.0.0'
-        } -RepositoryUrl 'https://code.example.com/group/project' -RepositoryProvider 'GitLab'
+        } -RepositoryState ([pscustomobject]@{
+                RepositoryUrl             = 'https://code.example.com/group/project'
+                RepositoryProvider        = 'GitLab'
+                RepositoryTargetReference = ''
+            })
 
         $result.UnreleasedCompareLinkPrefix | Should -Be 'https://code.example.com/group/project/-/compare/'
         $result.UpdatedUnreleasedLink | Should -Be 'https://code.example.com/group/project/-/compare/1.0.0...HEAD'
         $result.NewReleaseLink | Should -Be 'https://code.example.com/group/project/-/tags/1.0.0'
+    }
+
+    It 'builds Azure DevOps compare links when the provider-specific refs are supplied' {
+        $result = Resolve-KeepAChangelogReleaseData -Text @'
+# Changelog
+
+## [Unreleased]
+
+### Added
+
+- Initial release notes.
+'@ -Release @{
+            Version   = '13.0.4'
+            Date      = '2026-05-03'
+            Tag       = '13.0.4'
+            Reference = 'GTv13.0.4'
+        } -RepositoryState ([pscustomobject]@{
+                RepositoryUrl             = 'https://ado.example.com/Org/Project/_git/Tools'
+                RepositoryProvider        = 'AzureDevOps'
+                RepositoryTargetReference = 'GBdevelop'
+            })
+
+        $result.UnreleasedCompareLinkPrefix | Should -Be 'https://ado.example.com/Org/Project/_git/Tools/branchCompare?baseVersion='
+        $result.UpdatedUnreleasedLink | Should -Be 'https://ado.example.com/Org/Project/_git/Tools/branchCompare?baseVersion=GTv13.0.4&targetVersion=GBdevelop&_a=commits'
+        $result.NewReleaseLink | Should -Be 'https://ado.example.com/Org/Project/_git/Tools/branchCompare?baseVersion=GTv13.0.4&targetVersion=GTv13.0.4&_a=commits'
     }
 }

--- a/tests/private/shared/Get-KeepAChangelogRepositoryLinkData.Tests.ps1
+++ b/tests/private/shared/Get-KeepAChangelogRepositoryLinkData.Tests.ps1
@@ -10,34 +10,61 @@ BeforeAll {
 
 Describe 'Get-KeepAChangelogRepositoryLinkData' {
     It 'returns null link data when neither a repository URL nor compare prefix is available' {
-        $result = Get-KeepAChangelogRepositoryLinkData
+        $result = Get-KeepAChangelogRepositoryLinkData -RepositoryState ([pscustomobject]@{
+                RepositoryUrl             = ''
+                RepositoryProvider        = ''
+                RepositoryTargetReference = ''
+                UnreleasedCompareLinkPrefix = ''
+                UnreleasedTargetReference = ''
+            })
 
-        $result.RepositoryProvider | Should -BeNullOrEmpty
-        $result.RepositoryUrl | Should -BeNullOrEmpty
-        $result.UnreleasedCompareLinkPrefix | Should -BeNullOrEmpty
-        $result.ReleaseTagPrefix | Should -BeNullOrEmpty
+        $result | Should -BeNullOrEmpty
     }
 
     It 'builds provider-specific compare and tag prefixes from a repository URL' -ForEach @(
         @{
             ExpectedProvider           = 'GitHub'
+            RepositoryProvider         = ''
+            RepositoryTargetReference  = ''
             RepositoryUrl               = 'https://github.com/example/repo'
             UnreleasedCompareLinkPrefix = 'https://github.com/example/repo/compare/'
             ReleaseTagPrefix            = 'https://github.com/example/repo/releases/tag/'
+            UnreleasedTargetReference   = 'HEAD'
         }
         @{
             ExpectedProvider           = 'GitLab'
+            RepositoryProvider         = ''
+            RepositoryTargetReference  = ''
             RepositoryUrl               = 'https://gitlab.com/example/repo'
             UnreleasedCompareLinkPrefix = 'https://gitlab.com/example/repo/-/compare/'
             ReleaseTagPrefix            = 'https://gitlab.com/example/repo/-/tags/'
+            UnreleasedTargetReference   = 'HEAD'
+        }
+        @{
+            ExpectedProvider            = 'AzureDevOps'
+            RepositoryUrl               = 'https://ado.example.com/Org/Project/_git/Tools'
+            RepositoryProvider          = 'AzureDevOps'
+            RepositoryTargetReference   = 'GBdevelop'
+            UnreleasedCompareLinkPrefix = 'https://ado.example.com/Org/Project/_git/Tools/branchCompare?baseVersion='
+            ReleaseTagPrefix            = $null
+            UnreleasedTargetReference   = 'GBdevelop'
         }
     ) {
-        $result = Get-KeepAChangelogRepositoryLinkData -RepositoryUrl $RepositoryUrl
+        $result = Get-KeepAChangelogRepositoryLinkData -RepositoryState ([pscustomobject]@{
+                RepositoryUrl             = $RepositoryUrl
+                RepositoryProvider        = $RepositoryProvider
+                RepositoryTargetReference = $RepositoryTargetReference
+                UnreleasedCompareLinkPrefix = ''
+                UnreleasedTargetReference = ''
+            })
 
         $result.RepositoryProvider | Should -Be $ExpectedProvider
         $result.RepositoryUrl | Should -Be $RepositoryUrl
         $result.UnreleasedCompareLinkPrefix | Should -Be $UnreleasedCompareLinkPrefix
         $result.ReleaseTagPrefix | Should -Be $ReleaseTagPrefix
+        if (-not [string]::IsNullOrWhiteSpace($UnreleasedTargetReference)) {
+            $result.UnreleasedTargetReference | Should -Be $UnreleasedTargetReference
+        }
     }
 
     It 'derives the repository URL and tag prefix from an existing compare prefix' -ForEach @(
@@ -46,44 +73,100 @@ Describe 'Get-KeepAChangelogRepositoryLinkData' {
             RepositoryUrl               = 'https://github.com/example/repo'
             UnreleasedCompareLinkPrefix = 'https://github.com/example/repo/compare/'
             ReleaseTagPrefix            = 'https://github.com/example/repo/releases/tag/'
+            UnreleasedTargetReference   = 'HEAD'
         }
         @{
             ExpectedProvider           = 'GitLab'
             RepositoryUrl               = 'https://gitlab.com/example/repo'
             UnreleasedCompareLinkPrefix = 'https://gitlab.com/example/repo/-/compare/'
             ReleaseTagPrefix            = 'https://gitlab.com/example/repo/-/tags/'
+            UnreleasedTargetReference   = 'HEAD'
+        }
+        @{
+            ExpectedProvider            = 'AzureDevOps'
+            RepositoryUrl               = 'https://ado.example.com/Org/Project/_git/Tools'
+            UnreleasedCompareLinkPrefix = 'https://ado.example.com/Org/Project/_git/Tools/branchCompare?baseVersion='
+            ReleaseTagPrefix            = $null
+            UnreleasedTargetReference   = 'GBdevelop'
         }
     ) {
-        $result = Get-KeepAChangelogRepositoryLinkData -UnreleasedCompareLinkPrefix $UnreleasedCompareLinkPrefix
+        $result = Get-KeepAChangelogRepositoryLinkData -RepositoryState ([pscustomobject]@{
+                RepositoryUrl             = ''
+                RepositoryProvider        = ''
+                RepositoryTargetReference = ''
+                UnreleasedCompareLinkPrefix = $UnreleasedCompareLinkPrefix
+                UnreleasedTargetReference = $UnreleasedTargetReference
+            })
 
         $result.RepositoryProvider | Should -Be $ExpectedProvider
         $result.RepositoryUrl | Should -Be $RepositoryUrl
         $result.UnreleasedCompareLinkPrefix | Should -Be $UnreleasedCompareLinkPrefix
         $result.ReleaseTagPrefix | Should -Be $ReleaseTagPrefix
+        $result.UnreleasedTargetReference | Should -Be $UnreleasedTargetReference
     }
 
     It 'treats blank repository URLs as non-GitLab URLs' {
         Test-KeepAChangelogGitLabRepositoryUrl -RepositoryUrl '   ' | Should -BeFalse
     }
 
-    It 'uses the explicit provider for self-hosted GitLab repository URLs' {
-        $result = Get-KeepAChangelogRepositoryLinkData `
-            -RepositoryUrl 'https://code.example.com/group/project' `
-            -RepositoryProvider 'GitLab'
+    It 'detects Azure DevOps repository URLs from the _git path' {
+        Test-KeepAChangelogAzureDevOpsRepositoryUrl -RepositoryUrl 'https://ado.example.com/Org/Project/_git/Tools' | Should -BeTrue
+    }
 
-        $result.RepositoryProvider | Should -Be 'GitLab'
+    It 'does not detect Azure DevOps for non-_git repository URLs' {
+        Test-KeepAChangelogAzureDevOpsRepositoryUrl -RepositoryUrl 'https://github.com/example/repo' | Should -BeFalse
+    }
+
+    It 'applies provider selection rules for self-hosted repository URLs' -ForEach @(
+        @{
+            Name                        = 'uses the explicit provider for self-hosted GitLab repository URLs'
+            RepositoryProvider          = 'GitLab'
+            UnreleasedCompareLinkPrefix = ''
+            ExpectedProvider            = 'GitLab'
+        }
+        @{
+            Name                        = 'preserves the existing compare-link provider over an explicit parameter'
+            RepositoryProvider          = 'GitHub'
+            UnreleasedCompareLinkPrefix = 'https://code.example.com/group/project/-/compare/'
+            ExpectedProvider            = 'GitLab'
+        }
+    ) {
+        $result = Get-KeepAChangelogRepositoryLinkData -RepositoryState ([pscustomobject]@{
+                RepositoryUrl             = 'https://code.example.com/group/project'
+                RepositoryProvider        = $RepositoryProvider
+                RepositoryTargetReference = ''
+                UnreleasedCompareLinkPrefix = $UnreleasedCompareLinkPrefix
+                UnreleasedTargetReference = ''
+            })
+
+        $result.RepositoryProvider | Should -Be $ExpectedProvider
         $result.UnreleasedCompareLinkPrefix | Should -Be 'https://code.example.com/group/project/-/compare/'
         $result.ReleaseTagPrefix | Should -Be 'https://code.example.com/group/project/-/tags/'
     }
 
-    It 'preserves the existing compare-link provider over an explicit parameter' {
-        $result = Get-KeepAChangelogRepositoryLinkData `
-            -RepositoryUrl 'https://code.example.com/group/project' `
-            -RepositoryProvider 'GitHub' `
-            -UnreleasedCompareLinkPrefix 'https://code.example.com/group/project/-/compare/'
+    It 'requires RepositoryTargetReference when Azure DevOps footer links must be generated' {
+        {
+            Get-KeepAChangelogRepositoryLinkData -RepositoryState ([pscustomobject]@{
+                    RepositoryUrl             = 'https://ado.example.com/Org/Project/_git/Tools'
+                    RepositoryProvider        = 'AzureDevOps'
+                    RepositoryTargetReference = ''
+                    UnreleasedCompareLinkPrefix = ''
+                    UnreleasedTargetReference = ''
+                })
+        } | Should -Throw 'RepositoryTargetReference is required when AzureDevOps footer links must be generated.'
+    }
 
-        $result.RepositoryProvider | Should -Be 'GitLab'
-        $result.UnreleasedCompareLinkPrefix | Should -Be 'https://code.example.com/group/project/-/compare/'
-        $result.ReleaseTagPrefix | Should -Be 'https://code.example.com/group/project/-/tags/'
+    It 'infers Azure DevOps from the repository URL when the path uses _git' {
+        $result = Get-KeepAChangelogRepositoryLinkData -RepositoryState ([pscustomobject]@{
+                RepositoryUrl             = 'https://ado.example.com/Org/Project/_git/Tools'
+                RepositoryProvider        = ''
+                RepositoryTargetReference = 'GBdevelop'
+                UnreleasedCompareLinkPrefix = ''
+                UnreleasedTargetReference = ''
+            })
+
+        $result.RepositoryProvider | Should -Be 'AzureDevOps'
+        $result.UnreleasedCompareLinkPrefix | Should -Be 'https://ado.example.com/Org/Project/_git/Tools/branchCompare?baseVersion='
+        $result.UnreleasedTargetReference | Should -Be 'GBdevelop'
     }
 }

--- a/tests/private/shared/Get-KeepAChangelogRepositoryProviderParameterDictionary.Tests.ps1
+++ b/tests/private/shared/Get-KeepAChangelogRepositoryProviderParameterDictionary.Tests.ps1
@@ -16,6 +16,17 @@ Describe 'Get-KeepAChangelogRepositoryProviderParameterDictionary' {
 
         $parameter.Name | Should -Be 'RepositoryProvider'
         $parameter.ParameterType | Should -Be ([string])
-        $validateSet.ValidValues | Should -Be @('GitHub', 'GitLab')
+        $validateSet.ValidValues | Should -Be @('GitHub', 'GitLab', 'AzureDevOps')
+    }
+
+    It 'adds the optional Azure DevOps reference parameters when requested' {
+        $result = Get-KeepAChangelogRepositoryProviderParameterDictionary `
+            -IncludeRepositoryTargetReference `
+            -IncludeReleaseReference
+
+        $result.ContainsKey('RepositoryTargetReference') | Should -BeTrue
+        $result.ContainsKey('ReleaseReference') | Should -BeTrue
+        $result['RepositoryTargetReference'].ParameterType | Should -Be ([string])
+        $result['ReleaseReference'].ParameterType | Should -Be ([string])
     }
 }

--- a/tests/private/validation/Get-UnreleasedCompareLinkMatch.Tests.ps1
+++ b/tests/private/validation/Get-UnreleasedCompareLinkMatch.Tests.ps1
@@ -12,9 +12,21 @@ Describe 'Get-UnreleasedCompareLinkMatch' {
     It 'extracts the compare prefix and previous release reference' -ForEach @(
         @{
             Prefix = 'https://github.com/example/repo/compare/'
+            From   = '1.5.0'
+            Target = 'HEAD'
+            LinkSuffix = '...HEAD'
         }
         @{
             Prefix = 'https://gitlab.com/example/repo/-/compare/'
+            From   = '1.5.0'
+            Target = 'HEAD'
+            LinkSuffix = '...HEAD'
+        }
+        @{
+            Prefix = 'https://ado.example.com/Org/Project/_git/Tools/branchCompare?baseVersion='
+            From   = 'GTv13.0.3'
+            Target = 'GBdevelop'
+            LinkSuffix = '&targetVersion=GBdevelop&_a=commits'
         }
     ) {
         $match = Get-UnreleasedCompareLinkMatch -Text @"
@@ -22,12 +34,13 @@ Describe 'Get-UnreleasedCompareLinkMatch' {
 
 ## [Unreleased]
 
-[Unreleased]: $Prefix`1.5.0...HEAD
+[Unreleased]: $Prefix$From$LinkSuffix
 "@
 
         $match.Success | Should -BeTrue
         $match.Groups['prefix'].Value | Should -Be $Prefix
-        $match.Groups['from'].Value | Should -Be '1.5.0'
+        $match.Groups['from'].Value | Should -Be $From
+        $match.Groups['target'].Value | Should -Be $Target
     }
 
     It 'throws when the Unreleased compare link is missing' {

--- a/tests/public/Initialize-KeepAChangelogFile.Tests.ps1
+++ b/tests/public/Initialize-KeepAChangelogFile.Tests.ps1
@@ -18,7 +18,8 @@ Describe 'Initialize-KeepAChangelogFile' {
             Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] }
 
         $command.Parameters.ContainsKey('RepositoryProvider') | Should -BeTrue
-        $validateSet.ValidValues | Should -Be @('GitHub', 'GitLab')
+        $command.Parameters.ContainsKey('RepositoryTargetReference') | Should -BeTrue
+        $validateSet.ValidValues | Should -Be @('GitHub', 'GitLab', 'AzureDevOps')
     }
 
     It 'creates a changelog template with standard headings and an Unreleased compare link when PreviousReleaseReference is provided' -ForEach @(
@@ -27,6 +28,8 @@ Describe 'Initialize-KeepAChangelogFile' {
             FileName              = 'CHANGELOG-github.md'
             RepositoryUrl         = 'https://github.com/example/repo'
             RepositoryProvider    = 'GitHub'
+            PreviousReleaseReference = $null
+            RepositoryTargetReference = ''
             ExpectedFooterPattern = '\[Unreleased\]: https://github\.com/example/repo/compare/1\.0\.0\.\.\.HEAD'
         }
         @{
@@ -34,6 +37,8 @@ Describe 'Initialize-KeepAChangelogFile' {
             FileName              = 'CHANGELOG-gitlab.md'
             RepositoryUrl         = 'https://gitlab.com/example/repo'
             RepositoryProvider    = ''
+            PreviousReleaseReference = $null
+            RepositoryTargetReference = ''
             ExpectedFooterPattern = '\[Unreleased\]: https://gitlab\.com/example/repo/-/compare/1\.0\.0\.\.\.HEAD'
         }
         @{
@@ -41,7 +46,18 @@ Describe 'Initialize-KeepAChangelogFile' {
             FileName              = 'CHANGELOG-self-hosted-gitlab.md'
             RepositoryUrl         = 'https://code.example.com/group/project'
             RepositoryProvider    = 'GitLab'
+            PreviousReleaseReference = $null
+            RepositoryTargetReference = ''
             ExpectedFooterPattern = '\[Unreleased\]: https://code\.example\.com/group/project/-/compare/1\.0\.0\.\.\.HEAD'
+        }
+        @{
+            Name                      = 'Azure DevOps repository URLs with explicit target and provider'
+            FileName                  = 'CHANGELOG-azure-devops.md'
+            RepositoryUrl             = 'https://ado.example.com/Org/Project/_git/Tools'
+            RepositoryProvider        = 'AzureDevOps'
+            PreviousReleaseReference  = 'GTv1.0.0'
+            RepositoryTargetReference = 'GBdevelop'
+            ExpectedFooterPattern     = '\[Unreleased\]: https://ado\.example\.com/Org/Project/_git/Tools/branchCompare\?baseVersion=GTv1\.0\.0&targetVersion=GBdevelop&_a=commits'
         }
     ) {
         $path = Join-Path $TestDrive $FileName
@@ -49,11 +65,15 @@ Describe 'Initialize-KeepAChangelogFile' {
         $parameters = @{
             Path                     = $path
             RepositoryUrl            = $RepositoryUrl
-            PreviousReleaseReference = '1.0.0'
+            PreviousReleaseReference = if ($null -ne $PreviousReleaseReference) { $PreviousReleaseReference } else { '1.0.0' }
         }
 
         if (-not [string]::IsNullOrWhiteSpace($RepositoryProvider)) {
             $parameters.RepositoryProvider = $RepositoryProvider
+        }
+
+        if (-not [string]::IsNullOrWhiteSpace($RepositoryTargetReference)) {
+            $parameters.RepositoryTargetReference = $RepositoryTargetReference
         }
 
         $result = Initialize-KeepAChangelogFile @parameters
@@ -92,6 +112,18 @@ Describe 'Initialize-KeepAChangelogFile' {
 
         $result.PreviousReleaseReference | Should -Be 'develop'
         $text | Should -Match '\[Unreleased\]: https://github\.com/example/repo/compare/develop\.\.\.HEAD'
+    }
+
+    It 'requires RepositoryTargetReference when Azure DevOps footer links must be generated' {
+        $path = Join-Path $TestDrive 'CHANGELOG-azure-missing-target.md'
+
+        {
+            Initialize-KeepAChangelogFile `
+                -Path $path `
+                -RepositoryUrl 'https://ado.example.com/Org/Project/_git/Tools' `
+                -RepositoryProvider 'AzureDevOps' `
+                -PreviousReleaseReference 'GTv1.0.0'
+        } | Should -Throw 'RepositoryTargetReference is required when AzureDevOps footer links must be generated.'
     }
 
     It 'does not export the old New-KeepAChangelogFile command name' {

--- a/tests/public/Move-UnreleasedChangelog.Tests.ps1
+++ b/tests/public/Move-UnreleasedChangelog.Tests.ps1
@@ -113,7 +113,9 @@ Describe 'Move-UnreleasedChangelog' {
             Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] }
 
         $command.Parameters.ContainsKey('RepositoryProvider') | Should -BeTrue
-        $validateSet.ValidValues | Should -Be @('GitHub', 'GitLab')
+        $command.Parameters.ContainsKey('RepositoryTargetReference') | Should -BeTrue
+        $command.Parameters.ContainsKey('ReleaseReference') | Should -BeTrue
+        $validateSet.ValidValues | Should -Be @('GitHub', 'GitLab', 'AzureDevOps')
     }
 
     It 'moves unreleased notes into a release section, clears Unreleased, and updates compare links' {
@@ -317,6 +319,8 @@ $footer
             FileName                 = 'CHANGELOG.md'
             RepositoryUrl            = 'https://github.com/example/repo'
             RepositoryProvider       = ''
+            RepositoryTargetReference = ''
+            ReleaseReference          = ''
             ExpectedReleaseLink      = 'https://github.com/example/repo/releases/tag/1.0.0'
             ExpectedUnreleasedFooter = '\[Unreleased\]: https://github\.com/example/repo/compare/1\.0\.0\.\.\.HEAD'
             ExpectedReleaseFooter    = '\[1\.0\.0\]: https://github\.com/example/repo/releases/tag/1\.0\.0'
@@ -326,9 +330,22 @@ $footer
             FileName                 = 'CHANGELOG-gitlab-first-release.md'
             RepositoryUrl            = 'https://code.example.com/group/project'
             RepositoryProvider       = 'GitLab'
+            RepositoryTargetReference = ''
+            ReleaseReference          = ''
             ExpectedReleaseLink      = 'https://code.example.com/group/project/-/tags/1.0.0'
             ExpectedUnreleasedFooter = '\[Unreleased\]: https://code\.example\.com/group/project/-/compare/1\.0\.0\.\.\.HEAD'
             ExpectedReleaseFooter    = '\[1\.0\.0\]: https://code\.example\.com/group/project/-/tags/1\.0\.0'
+        }
+        @{
+            Name                      = 'Azure DevOps repository URLs with explicit target and release refs'
+            FileName                  = 'CHANGELOG-azure-first-release.md'
+            RepositoryUrl             = 'https://ado.example.com/Org/Project/_git/Tools'
+            RepositoryProvider        = 'AzureDevOps'
+            RepositoryTargetReference = 'GBdevelop'
+            ReleaseReference          = 'GTv1.0.0'
+            ExpectedReleaseLink       = 'https://ado.example.com/Org/Project/_git/Tools/branchCompare?baseVersion=GTv1.0.0&targetVersion=GTv1.0.0&_a=commits'
+            ExpectedUnreleasedFooter  = '\[Unreleased\]: https://ado\.example\.com/Org/Project/_git/Tools/branchCompare\?baseVersion=GTv1\.0\.0&targetVersion=GBdevelop&_a=commits'
+            ExpectedReleaseFooter     = '\[1\.0\.0\]: https://ado\.example\.com/Org/Project/_git/Tools/branchCompare\?baseVersion=GTv1\.0\.0&targetVersion=GTv1\.0\.0&_a=commits'
         }
     ) {
         $path = Join-Path $TestDrive $FileName
@@ -354,6 +371,14 @@ $footer
             $parameters.RepositoryProvider = $RepositoryProvider
         }
 
+        if (-not [string]::IsNullOrWhiteSpace($RepositoryTargetReference)) {
+            $parameters.RepositoryTargetReference = $RepositoryTargetReference
+        }
+
+        if (-not [string]::IsNullOrWhiteSpace($ReleaseReference)) {
+            $parameters.ReleaseReference = $ReleaseReference
+        }
+
         $result = Move-UnreleasedChangelog @parameters
         $updated = Get-Content -LiteralPath $path -Raw
 
@@ -362,6 +387,42 @@ $footer
         $result.NewReleaseLink | Should -Be $ExpectedReleaseLink
         $updated | Should -Match $ExpectedUnreleasedFooter
         $updated | Should -Match $ExpectedReleaseFooter
+    }
+
+    It 'updates Azure DevOps compare links when the release reference is supplied explicitly' {
+        $path = Join-Path $TestDrive 'CHANGELOG-azure-existing-footer.md'
+
+        @'
+# Changelog
+
+## [Unreleased]
+
+### Added
+
+- Azure DevOps follow-up notes.
+
+## [13.0.3] - 2026-05-01
+
+### Added
+
+- Previous release notes.
+
+[Unreleased]: https://ado.example.com/Org/Project/_git/Tools/branchCompare?baseVersion=GTv13.0.3&targetVersion=GBdevelop&_a=commits
+[13.0.3]: https://ado.example.com/Org/Project/_git/Tools/branchCompare?baseVersion=GTv13.0.2&targetVersion=GTv13.0.3&_a=commits
+'@ | Set-Content -LiteralPath $path -Encoding utf8
+
+        $result = Move-UnreleasedChangelog `
+            -Path $path `
+            -Version '13.0.4' `
+            -Date '2026-05-02' `
+            -ReleaseReference 'GTv13.0.4'
+        $updated = Get-Content -LiteralPath $path -Raw
+
+        $result.PreviousReleaseReference | Should -Be 'GTv13.0.3'
+        $result.NewReleaseCompareLink | Should -Be 'https://ado.example.com/Org/Project/_git/Tools/branchCompare?baseVersion=GTv13.0.3&targetVersion=GTv13.0.4&_a=commits'
+        $result.NewReleaseLink | Should -Be 'https://ado.example.com/Org/Project/_git/Tools/branchCompare?baseVersion=GTv13.0.3&targetVersion=GTv13.0.4&_a=commits'
+        $updated | Should -Match '\[Unreleased\]: https://ado\.example\.com/Org/Project/_git/Tools/branchCompare\?baseVersion=GTv13\.0\.4&targetVersion=GBdevelop&_a=commits'
+        $updated | Should -Match '\[13\.0\.4\]: https://ado\.example\.com/Org/Project/_git/Tools/branchCompare\?baseVersion=GTv13\.0\.3&targetVersion=GTv13\.0\.4&_a=commits'
     }
 
     It 'keeps footer links omitted for <Name>' -ForEach @(

--- a/tests/public/Test-KeepAChangelogFile.Tests.ps1
+++ b/tests/public/Test-KeepAChangelogFile.Tests.ps1
@@ -194,6 +194,35 @@ Describe 'Test-KeepAChangelogFile' {
         $result.PreviousReleaseReference | Should -Be '1.0.0'
     }
 
+    It 'accepts Azure DevOps compare links in the reference footer' {
+        $path = Join-Path $TestDrive 'CHANGELOG-azure.md'
+
+        @'
+# Changelog
+
+## [Unreleased]
+
+### Added
+
+## [13.0.3] - 2026-05-01
+
+### Added
+
+- Initial release.
+
+[Unreleased]: https://ado.example.com/Org/Project/_git/Tools/branchCompare?baseVersion=GTv13.0.3&targetVersion=GBdevelop&_a=commits
+[13.0.3]: https://ado.example.com/Org/Project/_git/Tools/branchCompare?baseVersion=GTv13.0.2&targetVersion=GTv13.0.3&_a=commits
+'@ | Set-Content -LiteralPath $path -Encoding utf8
+
+        $result = Test-KeepAChangelogFile -Path $path
+
+        $result.IsValid | Should -BeTrue
+        @($result.Errors).Count | Should -Be 0
+        $result.UnreleasedCompareLinkPrefix | Should -Be 'https://ado.example.com/Org/Project/_git/Tools/branchCompare?baseVersion='
+        $result.UnreleasedTargetReference | Should -Be 'GBdevelop'
+        $result.PreviousReleaseReference | Should -Be 'GTv13.0.3'
+    }
+
     It 'accepts yanked release headings that follow the Keep a Changelog format' {
         $caseList = @(
             @{


### PR DESCRIPTION
## Summary
 
 - Added Azure DevOps support to the provider-aware changelog footer workflow so `Initialize-KeepAChangelogFile`, `Move-UnreleasedChangelog`, and `Test-KeepAChangelogFile` now handle GitHub, GitLab, and Azure DevOps compare-link formats consistently.
 - Added the Azure-specific public parameters needed to generate correct `branchCompare` links: `-RepositoryTargetReference` and `-ReleaseReference`, while keeping existing GitHub and GitLab behavior intact.
 - Updated mirrored tests, command help, `CHANGELOG.md`, and `RELEASE_NOTE.md` to match the final public behavior.
 - Implements #22 and builds on the earlier provider-aware footer-link work from #23.
 
 ## Affected area
 
 - [x] Public PowerShell cmdlet behavior
 - [ ] Scaffolding or project layout
 - [ ] Build, test, analyzer, or CI behavior
 - [x] Release, changelog, or versioning flow
 - [ ] Contributor documentation
 - [ ] End-user documentation
 - [x] Command help
 - [ ] Other
 
 ## Review guidance
 
 - Highest-risk path: provider-aware footer generation and parsing across `Initialize-KeepAChangelogFile`, `Move-UnreleasedChangelog`, `Resolve-KeepAChangelogReleaseData`, and `Get-KeepAChangelogRepositoryLinkData`.
 - Main files changed: `src/public/`, `src/private/shared/`, `src/private/release/`, `src/private/validation/`, mirrored tests under `tests/`, and help/release docs.
 - Release impact: this is currently unreleased on `0.2.6-preview` and will ship in the next stable release unless further changes land first. No publish, tag, or branch-version semantics changed.
 
 ## Validation
 
 - [x] `Invoke-NovaBuild`
 - [x] `Test-NovaBuild`
 - [x] Targeted validation for the changed path
 - [x] Full repository quality loop
 - [ ] Docs-only change; executable validation not needed
 
 Validation notes:
 
 ```text
 ./scripts/build/Invoke-ScriptAnalyzerCI.ps1
 Invoke-NovaBuild
 Test-NovaBuild
 codescene-pre_commit_code_health_safeguard
 
 Result:
 - ScriptAnalyzer: clean
 - Test-NovaBuild: passed
 - Coverage: 100% / 99% target
 - CodeScene pre-commit safeguard: passed
 - CHANGELOG.md validation: passed
 ```
 
 ## Documentation and release follow-up
 
 - [x] `README.md` reviewed and updated if needed
 - [x] `CONTRIBUTING.md` reviewed and updated if needed
 - [x] `CHANGELOG.md` reviewed and updated if needed
 - [x] `RELEASE_NOTE.md` reviewed and updated if needed
 - [x] Command help updated if needed
 - [ ] End-user docs updated if needed
 - [ ] No documentation or release-note updates were needed
 
 ## Maintainability, compatibility, and risk
 
 - [x] Maintainability impact considered
 - [x] No breaking change
 - [ ] Breaking change
 - [ ] CI or release impact
 
 Risk, rollout, or rollback notes:
 
 ```text
 This is an additive public-surface change. Existing GitHub and GitLab workflows remain supported, while Azure DevOps now has an explicit parameter contract for target and release refs. The main operational risk is incorrect user input for Azure ref tokens, so the help now documents that Azure base/target values are used literally when generating branchCompare links. Rollback is straightforward because the change is isolated to provider-aware link generation/parsing and unreleased documentation.
 ```